### PR TITLE
IDENTITY-5372: Improve API Access across the tenants

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/module/ResourceConfig.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/module/ResourceConfig.java
@@ -27,6 +27,7 @@ public class ResourceConfig implements Serializable {
     private String context;
     private String httpMethod;
     private boolean isSecured;
+    private boolean isCrossTenantAllowed;
     private String permissions;
 
     public String getContext() {
@@ -53,6 +54,14 @@ public class ResourceConfig implements Serializable {
         this.isSecured = isSecured;
     }
 
+    public boolean isCrossTenantAllowed() {
+        return isCrossTenantAllowed;
+    }
+
+    public void setIsCrossTenantAllowed(boolean isCrossTenantAllowed) {
+        this.isCrossTenantAllowed = isCrossTenantAllowed;
+    }
+
     public String getPermissions() {
         return permissions;
     }
@@ -60,6 +69,5 @@ public class ResourceConfig implements Serializable {
     public void setPermissions(String permissions) {
         this.permissions = permissions;
     }
-
 
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
@@ -58,9 +58,8 @@ public class AuthConfigurationUtil {
                     String httpMethod = resource.getAttributeValue(
                             new QName(Constants.RESOURCE_HTTP_METHOD_ATTR));
                     String context = resource.getAttributeValue(new QName(Constants.RESOURCE_CONTEXT_ATTR));
-
-
                     String isSecured = resource.getAttributeValue(new QName(Constants.RESOURCE_SECURED_ATTR));
+                    String isCrossTenantAllowed = resource.getAttributeValue(new QName(Constants.RESOURCE_CROSS_TENANT_ATTR));
 
                     StringBuilder permissionBuilder = new StringBuilder();
                     Iterator<OMElement> permissionsIterator = resource.getChildrenWithName(
@@ -84,6 +83,10 @@ public class AuthConfigurationUtil {
                     if ( StringUtils.isNotEmpty(isSecured) && (Boolean.TRUE.toString().equals(isSecured) ||
                             Boolean.FALSE.toString().equals(isSecured)) ) {
                         resourceConfig.setIsSecured(Boolean.parseBoolean(isSecured));
+                    }
+                    if (StringUtils.isNotEmpty(isCrossTenantAllowed) && (Boolean.TRUE.toString().equals(isCrossTenantAllowed) ||
+                            Boolean.FALSE.toString().equals(isCrossTenantAllowed))) {
+                        resourceConfig.setIsCrossTenantAllowed(Boolean.parseBoolean(isCrossTenantAllowed));
                     }
                     resourceConfig.setPermissions(permissionBuilder.toString());
                     resourceConfigMap.put(new ResourceConfigKey(context, httpMethod), resourceConfig);

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -9,6 +9,7 @@ public class Constants {
     public final static String RESOURCE_SECURED_ATTR = "secured";
     public final static String RESOURCE_HTTP_METHOD_ATTR = "http-method";
     public final static String RESOURCE_PERMISSION_ELE = "Permissions";
+    public final static String RESOURCE_CROSS_TENANT_ATTR = "cross-tenant";
 
     public final static String CLIENT_APP_AUTHENTICATION_ELE = "ClientAppAuthentication";
     public final static String APPLICATION_NAME_ATTR = "name";

--- a/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/AuthorizationContext.java
+++ b/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/AuthorizationContext.java
@@ -28,6 +28,8 @@ public class AuthorizationContext extends MessageContext {
 
     private User user;
     private String permissionString;
+    private boolean isCrossTenantAllowed;
+    private String tenantDomainFromURLMapping;
 
 
     public User getUser() {
@@ -46,6 +48,14 @@ public class AuthorizationContext extends MessageContext {
         this.permissionString = permissionString;
     }
 
+    public boolean isCrossTenantAllowed() {
+        return isCrossTenantAllowed;
+    }
+
+    public void setIsCrossTenantAllowed(boolean isCrossTenantAllowed) {
+        this.isCrossTenantAllowed = isCrossTenantAllowed;
+    }
+
     public String getContext() {
         return context;
     }
@@ -62,5 +72,12 @@ public class AuthorizationContext extends MessageContext {
         this.httpMethods = httpMethods;
     }
 
+    public String getTenantDomainFromURLMapping() {
+        return tenantDomainFromURLMapping;
+    }
+
+    public void setTenantDomainFromURLMapping(String tenantDomainFromURLMapping) {
+        this.tenantDomainFromURLMapping = tenantDomainFromURLMapping;
+    }
 
 }

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -33,7 +33,7 @@ import org.wso2.carbon.identity.authz.service.AuthorizationResult;
 import org.wso2.carbon.identity.authz.service.AuthorizationStatus;
 import org.wso2.carbon.identity.authz.service.exception.AuthzServiceServerException;
 import org.wso2.carbon.identity.authz.valve.internal.AuthorizationValveServiceHolder;
-
+import org.wso2.carbon.identity.authz.valve.util.Utils;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -52,7 +52,6 @@ public class AuthorizationValve extends ValveBase {
 
     @Override
     public void invoke(Request request, Response response) throws IOException, ServletException {
-        String requestURI = request.getRequestURI();
 
         AuthenticationContext authenticationContext = (AuthenticationContext) request.getAttribute(AUTH_CONTEXT);
 
@@ -62,16 +61,18 @@ public class AuthorizationValve extends ValveBase {
             ResourceConfig resourceConfig = authenticationContext.getResourceConfig();
             String contextPath = request.getContextPath();
             String httpMethod = request.getMethod();
-
+            String tenantDomainFromURLMapping = Utils.getTenantDomainFromURLMapping(request);
             AuthorizationContext authorizationContext = new AuthorizationContext();
             if ( resourceConfig != null && StringUtils.isNotEmpty(resourceConfig.getPermissions()) ) {
                 authorizationContext.setPermissionString(resourceConfig.getPermissions());
             }
-
+            if (resourceConfig != null) {
+                authorizationContext.setIsCrossTenantAllowed(resourceConfig.isCrossTenantAllowed());
+            }
             authorizationContext.setContext(contextPath);
             authorizationContext.setHttpMethods(httpMethod);
-
             authorizationContext.setUser(authenticationContext.getUser());
+            authorizationContext.setTenantDomainFromURLMapping(tenantDomainFromURLMapping);
             List<AuthorizationManager> authorizationManagerList =
                     AuthorizationValveServiceHolder.getInstance().getAuthorizationManagerList();
             AuthorizationManager authorizationManager = HandlerManager.getInstance().getFirstPriorityHandler

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.authz.valve.util;
+
+import org.apache.catalina.connector.Request;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+public class Utils {
+
+    public static String getTenantDomainFromURLMapping(Request request) {
+        String requestURI = request.getRequestURI();
+        String domain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
+
+        if (requestURI.contains("/t/")) {
+            String temp = requestURI.substring(requestURI.indexOf("/t/") + 3);
+            int index = temp.indexOf('/');
+            if (index != -1) {
+                temp = temp.substring(0, index);
+                domain = temp;
+            }
+        }
+        return domain;
+    }
+
+}


### PR DESCRIPTION
User can enable or disable cross tenant access for given a resource by defining **cross-tenant** attribute under **ResourceAccessControl** section in **identity.xml**.
Eg: <Resource context="(.*)/entitlement/(.*)" secured="true" http-method="all" **cross-tenant="true"**>
Defult value is **cross-tenant="false"**