### PR TITLE
Fix improvement of map scope to roles creation

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/HandlerManager.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/HandlerManager.java
@@ -150,8 +150,10 @@ public class HandlerManager {
             }
         }
         if (log.isDebugEnabled()) {
-            log.debug("Get first priority handler : " + identityMessageHandler.getName() + "(" +
-                    identityMessageHandler.getClass().getName() + ")");
+            if (identityMessageHandler != null) {
+                log.debug("Get first priority handler : " + identityMessageHandler.getName() + "("
+                        + identityMessageHandler.getClass().getName() + ")");
+            }
         }
         return identityMessageHandler;
     }

--- a/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/handler/AuthorizationHandler.java
+++ b/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/handler/AuthorizationHandler.java
@@ -56,18 +56,15 @@ public class AuthorizationHandler extends AbstractIdentityHandler {
         try {
             User user = authorizationContext.getUser();
             String userDomain = user.getTenantDomain();
-            String tenantDomainFromURLMapping = authorizationContext.getTenantDomainFromURLMapping();
             int tenantId = IdentityTenantUtil.getTenantId(userDomain);
             String permissionString = authorizationContext.getPermissionString();
-            boolean isCrossTenantAllowed = authorizationContext.isCrossTenantAllowed();
-
             RealmService realmService = AuthorizationServiceHolder.getInstance().getRealmService();
             UserRealm tenantUserRealm = realmService.getTenantUserRealm(tenantId);
 
             AuthorizationManager authorizationManager = tenantUserRealm.getAuthorizationManager();
-            boolean isUserAuthorized = authorizationManager.isUserAuthorized(user.getUserName(),
-                    permissionString, CarbonConstants.UI_PERMISSION_ACTION);
-            if (isUserAuthorized && (isCrossTenantAllowed || tenantDomainFromURLMapping.equals(userDomain))) {
+            boolean isUserAuthorized = authorizationManager
+                    .isUserAuthorized(user.getUserName(), permissionString, CarbonConstants.UI_PERMISSION_ACTION);
+            if (isUserAuthorized) {
                 authorizationResult.setAuthorizationStatus(AuthorizationStatus.GRANT);
             }
         } catch (UserStoreException e) {

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
@@ -19,11 +19,14 @@
 package org.wso2.carbon.identity.authz.valve.util;
 
 import org.apache.catalina.connector.Request;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 public class Utils {
 
     public static String getTenantDomainFromURLMapping(Request request) {
+
         String requestURI = request.getRequestURI();
         String domain = MultitenantConstants.SUPER_TENANT_DOMAIN_NAME;
 
@@ -38,4 +41,18 @@ public class Utils {
         return domain;
     }
 
+    /**
+     * Checks whether the tenantDomain from URL mapping and the tenantDomain get from the user name are same.
+     *
+     * @param authenticationContext Context of the authentication
+     * @param request               authentication request
+     * @return true if valid request
+     */
+    public static boolean isUserBelongsToRequestedTenant(AuthenticationContext authenticationContext, Request request) {
+
+        String tenantDomainFromURLMapping = getTenantDomainFromURLMapping(request);
+        User user = authenticationContext.getUser();
+        String userDomain = user.getTenantDomain();
+        return tenantDomainFromURLMapping.equals(userDomain);
+    }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
We could map scope to roles for a specific tenant with users from different tenants too.
issue: https://github.com/wso2/product-is/issues/5307

Issue 1:
If we add resource with secured="true" into identity.xml (<Resource context="(.)/api/identity/oauth2/v1.0/(.)" secured="true" http-method="all">) then the backend will authorize the request with the credentials. While authorizing, the system allows mapping scope to roles for a specific tenant with different users from the different tenant when cross-domain is false. It allows because in the code level we didn't check requesting tenant and tenant gets from the username. This fix allows the request for authorizing when the CrossTenant is true else the requesting tenant and tenant get from username is same. Otherwise, it will terminate the request.

We are checking that the requesting tenant and tenant get from username is same before authorize in the AuthorizationValve class.

Issue2:
If we didn't add any credentials in the request identityHandler should be null. so it prints null point exception in the console and gives a success response to the user. This fix will handle this issue also.
