### PR TITLE
Improve rest authentication valve to deny first approach

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
@@ -31,9 +31,10 @@ public class AuthConfigurationUtil {
     private List<String> intermediateCertCNList = new ArrayList<>();
     private List<String> exemptedContextList = new ArrayList<>();
     private boolean isIntermediateCertValidationEnabled = false;
-    public static final String SECRET_ALIAS = "secretAlias";
-    public static final String SECRET_ALIAS_NAMESPACE_URI = "http://org.wso2.securevault/configuration";
-    public static final String SECRET_ALIAS_PREFIX = "svns";
+    private static final String SECRET_ALIAS = "secretAlias";
+    private static final String SECRET_ALIAS_NAMESPACE_URI = "http://org.wso2.securevault/configuration";
+    private static final String SECRET_ALIAS_PREFIX = "svns";
+    private String defaultAccess;
 
     private static final Log log = LogFactory.getLog(AuthConfigurationUtil.class);
 
@@ -63,7 +64,7 @@ public class AuthConfigurationUtil {
         OMElement resourceAccessControl = IdentityConfigParser.getInstance().getConfigElement(Constants
                 .RESOURCE_ACCESS_CONTROL_ELE);
         if ( resourceAccessControl != null ) {
-
+            defaultAccess = resourceAccessControl.getAttributeValue(new QName(Constants.RESOURCE_DEFAULT_ACCESS));
             Iterator<OMElement> resources = resourceAccessControl.getChildrenWithName(
                     new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, Constants.RESOURCE_ELE));
             if ( resources != null ) {
@@ -220,5 +221,10 @@ public class AuthConfigurationUtil {
     public List<String> getExemptedContextList() {
 
         return exemptedContextList;
+    }
+
+    public String getDefaultAccess() {
+
+        return defaultAccess;
     }
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -5,6 +5,7 @@ public class Constants {
 
     public final static String RESOURCE_ACCESS_CONTROL_ELE = "ResourceAccessControl";
     public final static String RESOURCE_ELE = "Resource";
+    public final static String RESOURCE_DEFAULT_ACCESS = "default-access";
     public final static String RESOURCE_CONTEXT_ATTR = "context";
     public final static String RESOURCE_SECURED_ATTR = "secured";
     public final static String RESOURCE_HTTP_METHOD_ATTR = "http-method";
@@ -26,5 +27,6 @@ public class Constants {
     public static final String CERT_CN_ELE = "CertCN";
     public final static String CONTEXT_ELE = "Context";
     public final static String CERT_AUTHENTICATION_ENABLE_ATTR = "enable";
+    public final static String DENY_DEFAULT_ACCESS = "deny";
 
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Implement https://github.com/wso2/product-is/issues/5907


- Currently, rest authentication valve allows invoking any API endpoints and do the authentication and authorization only if it is configured to validate in identity.xml.

- This makes a security hole if it is forgotten to add an endpoint to the identity.xml. Then any user can access those APIs without having authentication or authorization.
- The purpose of this improvement is to deny access first and permit access only based on the configuration in the identity.xml file