### PR TITLE
Maintain the resource config order 

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.xml.namespace.QName;
@@ -26,7 +27,7 @@ public class AuthConfigurationUtil {
 
     private static AuthConfigurationUtil authConfigurationUtil = new AuthConfigurationUtil();
 
-    private Map<ResourceConfigKey, ResourceConfig> resourceConfigMap = new HashMap<>();
+    private Map<ResourceConfigKey, ResourceConfig> resourceConfigMap = new LinkedHashMap<>();
     private Map<String, String> applicationConfigMap = new HashMap<>();
     private List<String> intermediateCertCNList = new ArrayList<>();
     private List<String> exemptedContextList = new ArrayList<>();


### PR DESCRIPTION
The purpose of this fix is to maintain the order of the resource permission configuration. If there are multiple configurations matching for a given resource, priority will go to the first configured matching resource. 

Fixing https://github.com/wso2/product-is/issues/5966

