### PR TITLE
Fix empty basic auth header resulting an NPE and a 200 OK response

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.auth.service.handler;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.http.HttpHeaders;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
@@ -58,32 +58,32 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
 
     @Override
     public String getName() {
+
         return "BasicAuthentication";
     }
 
     @Override
     public int getPriority(MessageContext messageContext) {
+
         return getPriority(messageContext, 100);
     }
 
     @Override
     public boolean canHandle(MessageContext messageContext) {
-        if ( messageContext instanceof AuthenticationContext ) {
+
+        if (messageContext instanceof AuthenticationContext) {
             AuthenticationContext authenticationContext = (AuthenticationContext) messageContext;
             if (authenticationContext.getAuthenticationRequest() != null) {
                 String authorizationHeader = authenticationContext.getAuthenticationRequest().
                         getHeader(HttpHeaders.AUTHORIZATION);
-                if ( StringUtils.isNotEmpty(authorizationHeader) && authorizationHeader.startsWith(BASIC_AUTH_HEADER)
-                        ) {
-                    return true;
-                }
+                return StringUtils.isNotEmpty(authorizationHeader) && authorizationHeader.startsWith(BASIC_AUTH_HEADER);
             }
         }
         return false;
     }
 
     @Override
-    protected AuthenticationResult doAuthenticate(MessageContext messageContext) throws AuthServerException, AuthenticationFailException, AuthClientException {
+    protected AuthenticationResult doAuthenticate(MessageContext messageContext) throws AuthenticationFailException {
 
         AuthenticationResult authenticationResult = new AuthenticationResult(AuthenticationStatus.FAILED);
         AuthenticationContext authenticationContext = (AuthenticationContext) messageContext;
@@ -91,14 +91,14 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
                 getHeader(HttpHeaders.AUTHORIZATION);
 
         String[] splitAuthorizationHeader = authorizationHeader.split(" ");
-        if ( splitAuthorizationHeader != null && splitAuthorizationHeader.length == 2 ) {
-            byte[] decodedAuthHeader = Base64.decodeBase64(authorizationHeader.split(" ")[1].getBytes());
+        if (splitAuthorizationHeader.length == 2) {
+            byte[] decodedAuthHeader = Base64.decodeBase64(splitAuthorizationHeader[1].getBytes());
             String authHeader = new String(decodedAuthHeader, Charset.defaultCharset());
             String[] splitCredentials = authHeader.split(":");
-            if ( splitCredentials != null && splitCredentials.length == 2 ) {
+
+            if (splitCredentials.length == 2) {
                 String userName = splitCredentials[0];
                 String password = splitCredentials[1];
-
 
                 UserStoreManager userStoreManager = null;
                 try {
@@ -111,7 +111,6 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
 
                     authenticationContext.setUser(user);
 
-
                     //TODO: Related to this https://wso2.org/jira/browse/IDENTITY-4752 - Class IdentityMgtEventListener
                     // : Line 563: Have to check whether why we can't continue
                     //without following lines as previous code.
@@ -121,44 +120,41 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
 
                     UserRealm userRealm = AuthenticationServiceHolder.getInstance().getRealmService().
                             getTenantUserRealm(tenantId);
-                    if ( userRealm != null ) {
+                    if (userRealm != null) {
                         userStoreManager = (UserStoreManager) userRealm.getUserStoreManager();
                         boolean isAuthenticated = userStoreManager.authenticate(MultitenantUtils.
                                 getTenantAwareUsername(userName), password);
-                        if ( isAuthenticated ) {
+                        if (isAuthenticated) {
                             authenticationResult.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
-                            if ( log.isDebugEnabled() ) {
+                            if (log.isDebugEnabled()) {
                                 log.debug("BasicAuthentication success.");
                             }
                         }
-
                     } else {
-                        String errorMessage = "Error occurred while trying to load the user realm for the tenant.";
+                        String errorMessage = "Error occurred while trying to load the user realm for the tenant: " +
+                                tenantId;
                         log.error(errorMessage);
                         throw new AuthenticationFailException(errorMessage);
                     }
-                } catch ( org.wso2.carbon.user.api.UserStoreException e ) {
-                    String errorMessage = "Error occurred while trying to authenticate, " + e.getMessage();
+                } catch (org.wso2.carbon.user.api.UserStoreException e) {
+                    String errorMessage = "Error occurred while trying to authenticate. " + e.getMessage();
                     log.error(errorMessage);
                     throw new AuthenticationFailException(errorMessage);
                 } finally {
                     PrivilegedCarbonContext.endTenantFlow();
                 }
             } else {
-                String errorMessage = "Error occurred while trying to authenticate and  auth user credentials " +
-                        "are not define correctly.";
+                String errorMessage = "Error occurred while trying to authenticate. The auth user credentials " +
+                        "are not defined correctly.";
                 log.error(errorMessage);
                 throw new AuthenticationFailException(errorMessage);
             }
         } else {
-            String errorMessage = "Error occurred while trying to authenticate and  " + HttpHeaders.AUTHORIZATION
-                    + " header values are not define correctly.";
+            String errorMessage = "Error occurred while trying to authenticate. The " + HttpHeaders.AUTHORIZATION +
+                    " header values are not defined correctly.";
             log.error(errorMessage);
             throw new AuthenticationFailException(errorMessage);
         }
-
-
         return authenticationResult;
     }
-
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
@@ -94,9 +94,10 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
         if (splitAuthorizationHeader.length == 2) {
             byte[] decodedAuthHeader = Base64.decodeBase64(splitAuthorizationHeader[1].getBytes());
             String authHeader = new String(decodedAuthHeader, Charset.defaultCharset());
-            String[] splitCredentials = authHeader.split(":");
+            String[] splitCredentials = authHeader.split(":", 2);
 
-            if (splitCredentials.length == 2) {
+            if (splitCredentials.length == 2 && StringUtils.isNotBlank(splitCredentials[0]) &&
+                    StringUtils.isNotBlank(splitCredentials[1])) {
                 String userName = splitCredentials[0];
                 String password = splitCredentials[1];
 

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
@@ -127,7 +127,7 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
                         if (isAuthenticated) {
                             authenticationResult.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
                             if (log.isDebugEnabled()) {
-                                log.debug("BasicAuthentication success.");
+                                log.debug("Basic Authentication successful for the user: " + userName);
                             }
                         }
                     } else {

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
@@ -28,9 +28,7 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.auth.service.AuthenticationResult;
 import org.wso2.carbon.identity.auth.service.AuthenticationStatus;
-import org.wso2.carbon.identity.auth.service.exception.AuthClientException;
 import org.wso2.carbon.identity.auth.service.exception.AuthenticationFailException;
-import org.wso2.carbon.identity.auth.service.exception.AuthServerException;
 import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.internal.AuthenticationServiceHolder;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
@@ -41,6 +39,8 @@ import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.nio.charset.Charset;
+
+import static org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil.isAuthHeaderMatch;
 
 /**
  * BasicAuthenticationHandler is for authenticate the request based on Basic Authentication.
@@ -71,15 +71,7 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
     @Override
     public boolean canHandle(MessageContext messageContext) {
 
-        if (messageContext instanceof AuthenticationContext) {
-            AuthenticationContext authenticationContext = (AuthenticationContext) messageContext;
-            if (authenticationContext.getAuthenticationRequest() != null) {
-                String authorizationHeader = authenticationContext.getAuthenticationRequest().
-                        getHeader(HttpHeaders.AUTHORIZATION);
-                return StringUtils.isNotEmpty(authorizationHeader) && authorizationHeader.startsWith(BASIC_AUTH_HEADER);
-            }
-        }
-        return false;
+        return isAuthHeaderMatch(messageContext, BASIC_AUTH_HEADER);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
@@ -94,7 +94,7 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
         if ( splitAuthorizationHeader != null && splitAuthorizationHeader.length == 2 ) {
             byte[] decodedAuthHeader = Base64.decodeBase64(authorizationHeader.split(" ")[1].getBytes());
             String authHeader = new String(decodedAuthHeader, Charset.defaultCharset());
-            String[] splitCredentials = authHeader.split(":", 2);
+            String[] splitCredentials = authHeader.split(":");
             if ( splitCredentials != null && splitCredentials.length == 2 ) {
                 String userName = splitCredentials[0];
                 String password = splitCredentials[1];
@@ -148,13 +148,13 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
                 String errorMessage = "Error occurred while trying to authenticate and  auth user credentials " +
                         "are not define correctly.";
                 log.error(errorMessage);
-                throw new AuthClientException(errorMessage);
+                throw new AuthenticationFailException(errorMessage);
             }
         } else {
             String errorMessage = "Error occurred while trying to authenticate and  " + HttpHeaders.AUTHORIZATION
                     + " header values are not define correctly.";
             log.error(errorMessage);
-            throw new AuthClientException(errorMessage);
+            throw new AuthenticationFailException(errorMessage);
         }
 
 

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientAuthenticationHandler.java
@@ -92,9 +92,10 @@ public class ClientAuthenticationHandler extends AuthenticationHandler {
         if (splitAuthorizationHeader.length == 2) {
             byte[] decodedAuthHeader = Base64.decodeBase64(splitAuthorizationHeader[1].getBytes());
             String authHeader = new String(decodedAuthHeader, Charset.defaultCharset());
-            String[] splitCredentials = authHeader.split(":");
+            String[] splitCredentials = authHeader.split(":", 2);
 
-            if (splitCredentials.length == 2) {
+            if (splitCredentials.length == 2 && StringUtils.isNotBlank(splitCredentials[0]) &&
+                    StringUtils.isNotBlank(splitCredentials[1])) {
                 String appName = splitCredentials[0];
                 String password = splitCredentials[1];
                 String hash = AuthConfigurationUtil.getInstance().getClientAuthenticationHash(appName);
@@ -131,7 +132,7 @@ public class ClientAuthenticationHandler extends AuthenticationHandler {
                     }
                 }
             } else {
-                String errorMessage = "Error occurred while trying to authenticate. The uth application credentials "
+                String errorMessage = "Error occurred while trying to authenticate. The auth application credentials "
                         + "are not defined correctly.";
                 log.error(errorMessage);
                 throw new AuthenticationFailException(errorMessage);

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientAuthenticationHandler.java
@@ -26,8 +26,6 @@ import org.apache.http.HttpHeaders;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.auth.service.AuthenticationResult;
 import org.wso2.carbon.identity.auth.service.AuthenticationStatus;
-import org.wso2.carbon.identity.auth.service.exception.AuthClientException;
-import org.wso2.carbon.identity.auth.service.exception.AuthServerException;
 import org.wso2.carbon.identity.auth.service.exception.AuthenticationFailException;
 import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil;
@@ -37,6 +35,8 @@ import org.wso2.carbon.identity.core.handler.InitConfig;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+
+import static org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil.isAuthHeaderMatch;
 
 /**
  * ClientAuthenticationHandler is for authenticate the request based on Client Authentication.
@@ -68,16 +68,7 @@ public class ClientAuthenticationHandler extends AuthenticationHandler {
     @Override
     public boolean canHandle(MessageContext messageContext) {
 
-        if (messageContext instanceof AuthenticationContext) {
-            AuthenticationContext authenticationContext = (AuthenticationContext) messageContext;
-            if (authenticationContext.getAuthenticationRequest() != null) {
-                String authorizationHeader = authenticationContext.getAuthenticationRequest().
-                        getHeader(HttpHeaders.AUTHORIZATION);
-                return StringUtils.isNotEmpty(authorizationHeader) && authorizationHeader.startsWith(
-                        CLIENT_AUTH_HEADER);
-            }
-        }
-        return false;
+        return isAuthHeaderMatch(messageContext, CLIENT_AUTH_HEADER);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientAuthenticationHandler.java
@@ -55,32 +55,33 @@ public class ClientAuthenticationHandler extends AuthenticationHandler {
 
     @Override
     public String getName() {
+
         return "ClientAuthentication";
     }
 
     @Override
     public int getPriority(MessageContext messageContext) {
+
         return getPriority(messageContext, 130);
     }
 
     @Override
     public boolean canHandle(MessageContext messageContext) {
+
         if (messageContext instanceof AuthenticationContext) {
             AuthenticationContext authenticationContext = (AuthenticationContext) messageContext;
             if (authenticationContext.getAuthenticationRequest() != null) {
                 String authorizationHeader = authenticationContext.getAuthenticationRequest().
                         getHeader(HttpHeaders.AUTHORIZATION);
-                if (StringUtils.isNotEmpty(authorizationHeader) && authorizationHeader.startsWith(CLIENT_AUTH_HEADER)
-                        ) {
-                    return true;
-                }
+                return StringUtils.isNotEmpty(authorizationHeader) && authorizationHeader.startsWith(
+                        CLIENT_AUTH_HEADER);
             }
         }
         return false;
     }
 
     @Override
-    protected AuthenticationResult doAuthenticate(MessageContext messageContext) throws AuthServerException, AuthenticationFailException, AuthClientException {
+    protected AuthenticationResult doAuthenticate(MessageContext messageContext) throws AuthenticationFailException {
 
         AuthenticationResult authenticationResult = new AuthenticationResult(AuthenticationStatus.FAILED);
         AuthenticationContext authenticationContext = (AuthenticationContext) messageContext;
@@ -88,11 +89,12 @@ public class ClientAuthenticationHandler extends AuthenticationHandler {
                 getHeader(HttpHeaders.AUTHORIZATION);
 
         String[] splitAuthorizationHeader = authorizationHeader.split(" ");
-        if (splitAuthorizationHeader != null && splitAuthorizationHeader.length == 2) {
-            byte[] decodedAuthHeader = Base64.decodeBase64(authorizationHeader.split(" ")[1].getBytes());
+        if (splitAuthorizationHeader.length == 2) {
+            byte[] decodedAuthHeader = Base64.decodeBase64(splitAuthorizationHeader[1].getBytes());
             String authHeader = new String(decodedAuthHeader, Charset.defaultCharset());
             String[] splitCredentials = authHeader.split(":");
-            if (splitCredentials != null && splitCredentials.length == 2) {
+
+            if (splitCredentials.length == 2) {
                 String appName = splitCredentials[0];
                 String password = splitCredentials[1];
                 String hash = AuthConfigurationUtil.getInstance().getClientAuthenticationHash(appName);
@@ -106,16 +108,16 @@ public class ClientAuthenticationHandler extends AuthenticationHandler {
                         byte[] byteValue = dgst.digest(password.getBytes());
 
                         //convert the byte to hex format
-                        StringBuffer sb = new StringBuffer();
-                        for (int i = 0; i < byteValue.length; i++) {
-                            sb.append(Integer.toString((byteValue[i] & 0xff) + 0x100, 16).substring(1));
+                        StringBuilder sb = new StringBuilder();
+                        for (byte b : byteValue) {
+                            sb.append(Integer.toString((b & 0xff) + 0x100, 16).substring(1));
                         }
 
                         String hashFromRequest = sb.toString();
                         if (hash.equals(hashFromRequest)) {
                             authenticationResult.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
                             if (log.isDebugEnabled()) {
-                                log.debug("ClientAuthentication Success.");
+                                log.debug("Client Authentication Successful for the application: " + appName);
                             }
                         }
                     } catch (NoSuchAlgorithmException e) {
@@ -125,25 +127,21 @@ public class ClientAuthenticationHandler extends AuthenticationHandler {
                     }
                 } else {
                     if (log.isDebugEnabled()) {
-                        log.debug("No matching application configuration fould for :" + appName);
+                        log.debug("No matching application configuration found for :" + appName);
                     }
                 }
-
             } else {
-                String errorMessage = "Error occurred while trying to authenticate and  auth application credentials " +
-                        "are not define correctly.";
+                String errorMessage = "Error occurred while trying to authenticate. The uth application credentials "
+                        + "are not defined correctly.";
                 log.error(errorMessage);
-                throw new AuthClientException(errorMessage);
+                throw new AuthenticationFailException(errorMessage);
             }
         } else {
-            String errorMessage = "Error occurred while trying to authenticate and  " + HttpHeaders.AUTHORIZATION
-                    + " header values are not define correctly.";
+            String errorMessage = "Error occurred while trying to authenticate. The " + HttpHeaders.AUTHORIZATION +
+                    " header values are not defined correctly.";
             log.error(errorMessage);
-            throw new AuthClientException(errorMessage);
+            throw new AuthenticationFailException(errorMessage);
         }
-
-
         return authenticationResult;
     }
-
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -36,6 +36,8 @@ import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import static org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil.isAuthHeaderMatch;
+
 /**
  * OAuth2AccessTokenHandler is for authenticate the request based on Token.
  * canHandle method will confirm whether this request can be handled by this authenticator or not.
@@ -132,15 +134,6 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
     @Override
     public boolean canHandle(MessageContext messageContext) {
 
-        AuthenticationContext authenticationContext = (AuthenticationContext) messageContext;
-        AuthenticationRequest authenticationRequest = authenticationContext.getAuthenticationRequest();
-        if (authenticationRequest != null) {
-            String authorizationHeader = authenticationRequest.getHeader(HttpHeaders.AUTHORIZATION);
-            if (StringUtils.isNotEmpty(authorizationHeader) && authorizationHeader.startsWith(OAUTH_HEADER)) {
-                return true;
-            }
-        }
-        return false;
+        return isAuthHeaderMatch(messageContext, OAUTH_HEADER);
     }
-
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
@@ -4,10 +4,13 @@ import org.apache.axiom.om.OMElement;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHeaders;
+import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.internal.AuthenticationServiceHolder;
 import org.wso2.carbon.identity.auth.service.module.ResourceConfig;
 import org.wso2.carbon.identity.auth.service.module.ResourceConfigKey;
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityCoreConstants;
 import org.wso2.securevault.SecretResolver;
@@ -227,5 +230,28 @@ public class AuthConfigurationUtil {
     public String getDefaultAccess() {
 
         return defaultAccess;
+    }
+
+    /**
+     * Check if the authorization header is matching to the provided auth header identifier.
+     *
+     * @param messageContext       Authentication message context.
+     * @param authHeaderIdentifier Specific header identifier to be matched.
+     * @return True if matched, false otherwise.
+     */
+    public static boolean isAuthHeaderMatch(MessageContext messageContext, String authHeaderIdentifier) {
+
+        if (messageContext instanceof AuthenticationContext) {
+            AuthenticationContext authenticationContext = (AuthenticationContext) messageContext;
+            if (authenticationContext.getAuthenticationRequest() != null) {
+                String authorizationHeader = authenticationContext.getAuthenticationRequest().
+                        getHeader(HttpHeaders.AUTHORIZATION);
+                String[] splitAuthorizationHeader = authorizationHeader.split(" ");
+                return splitAuthorizationHeader.length > 0 &&
+                        StringUtils.isNotEmpty(splitAuthorizationHeader[0]) &&
+                        authHeaderIdentifier.equals(splitAuthorizationHeader[0]);
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request
- Changed basic header param splitting logic which caused the $subject.
- Consider all errors that could occur in the authentication process as _**401 unauthorized**_ errors.
- Fixed some styling and improved logs.

Fixes https://github.com/wso2/product-is/issues/6610