### PR TITLE
Secure internal rest APIs with scopes 

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -38,6 +38,9 @@ import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import static org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil.isAuthHeaderMatch;
 
+import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_ALLOWED_SCOPES;
+import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_VALIDATE_SCOPE;
+
 /**
  * OAuth2AccessTokenHandler is for authenticate the request based on Token.
  * canHandle method will confirm whether this request can be handled by this authenticator or not.
@@ -48,7 +51,6 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
     private static final Log log = LogFactory.getLog(OAuth2AccessTokenHandler.class);
     private final String OAUTH_HEADER = "Bearer";
     private final String CONSUMER_KEY = "consumer-key";
-    private final String OAUTH2_ALLOWED_SCOPES = "oauth2-allowed-scopes";
 
     @Override
     protected AuthenticationResult doAuthenticate(MessageContext messageContext) {
@@ -102,7 +104,7 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
 
                 authenticationContext.addParameter(CONSUMER_KEY, clientApplicationDTO.getConsumerKey());
                 authenticationContext.addParameter(OAUTH2_ALLOWED_SCOPES, responseDTO.getScope());
-
+                authenticationContext.addParameter(OAUTH2_VALIDATE_SCOPE, true);
             }
         }
         return authenticationResult;

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/module/ResourceConfig.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/module/ResourceConfig.java
@@ -34,6 +34,7 @@ public class ResourceConfig implements Serializable {
     private boolean isSecured;
     private boolean isCrossTenantAllowed;
     private String permissions;
+    private List<String> scopes;
     // Comma separated list of allowed authentication handler names. If all handlers are engaged the value is 'all'
     private String allowedAuthHandlers;
 
@@ -85,5 +86,15 @@ public class ResourceConfig implements Serializable {
     public void setAllowedAuthHandlers(String allowedAuthHandlers) {
 
         this.allowedAuthHandlers = allowedAuthHandlers;
+    }
+
+    public List<String> getScopes() {
+
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+
+        this.scopes = scopes;
     }
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
@@ -101,6 +101,16 @@ public class AuthConfigurationUtil {
                         }
                     }
 
+                    List<String> scopes = new ArrayList<>();
+                    Iterator<OMElement> scopesIterator = resource.getChildrenWithName(
+                            new QName(Constants.RESOURCE_SCOPE_ELE));
+                    if (scopesIterator != null) {
+                        while (scopesIterator.hasNext()) {
+                            OMElement scopeElement = scopesIterator.next();
+                            scopes.add(scopeElement.getText());
+                        }
+                    }
+
                     resourceConfig.setContext(context);
                     resourceConfig.setHttpMethod(httpMethod);
                     if ( StringUtils.isNotEmpty(isSecured) && (Boolean.TRUE.toString().equals(isSecured) ||
@@ -118,6 +128,7 @@ public class AuthConfigurationUtil {
                     }
                     resourceConfig.setAllowedAuthHandlers(allowedAuthHandlers);
                     resourceConfig.setPermissions(permissionBuilder.toString());
+                    resourceConfig.setScopes(scopes);
                     resourceConfigMap.put(new ResourceConfigKey(context, httpMethod), resourceConfig);
                 }
             }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -10,6 +10,9 @@ public class Constants {
     public final static String RESOURCE_SECURED_ATTR = "secured";
     public final static String RESOURCE_HTTP_METHOD_ATTR = "http-method";
     public final static String RESOURCE_PERMISSION_ELE = "Permissions";
+    public final static String RESOURCE_SCOPE_ELE = "Scopes";
+    public final static String OAUTH2_ALLOWED_SCOPES = "oauth2-allowed-scopes";
+    public final static String OAUTH2_VALIDATE_SCOPE = "oauth2-validate-scopes";
     public final static String RESOURCE_CROSS_TENANT_ATTR = "cross-tenant";
     public final static String RESOURCE_ALLOWED_AUTH_HANDLERS = "allowed-auth-handlers";
     public final static String RESOURCE_ALLOWED_AUTH_HANDLERS_ALL = "all";

--- a/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/AuthorizationContext.java
+++ b/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/AuthorizationContext.java
@@ -21,6 +21,9 @@ package org.wso2.carbon.identity.authz.service;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class AuthorizationContext extends MessageContext {
 
     private String context;
@@ -28,6 +31,7 @@ public class AuthorizationContext extends MessageContext {
 
     private User user;
     private String permissionString;
+    private List<String> requiredScopes;
     private boolean isCrossTenantAllowed;
     private String tenantDomainFromURLMapping;
 
@@ -80,4 +84,16 @@ public class AuthorizationContext extends MessageContext {
         this.tenantDomainFromURLMapping = tenantDomainFromURLMapping;
     }
 
+    public List<String> getRequiredScopes() {
+
+        if (requiredScopes == null) {
+            return new ArrayList<>();
+        }
+        return requiredScopes;
+    }
+
+    public void setRequiredScopes(List<String> requiredScopes) {
+
+        this.requiredScopes = requiredScopes;
+    }
 }

--- a/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/AuthorizationManager.java
+++ b/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/AuthorizationManager.java
@@ -17,9 +17,7 @@
  */
 package org.wso2.carbon.identity.authz.service;
 
-
 import org.apache.commons.lang.StringUtils;
-import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.handler.HandlerManager;
 import org.wso2.carbon.identity.authz.service.exception.AuthzServiceServerException;
 import org.wso2.carbon.identity.authz.service.handler.AuthorizationHandler;
@@ -27,7 +25,6 @@ import org.wso2.carbon.identity.authz.service.handler.ResourceHandler;
 import org.wso2.carbon.identity.authz.service.internal.AuthorizationServiceHolder;
 import org.wso2.carbon.identity.core.handler.IdentityHandler;
 import org.wso2.carbon.identity.core.handler.InitConfig;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 
 import java.util.List;
 
@@ -46,8 +43,9 @@ public class AuthorizationManager implements IdentityHandler {
 
         AuthorizationResult authorizationResult = new AuthorizationResult(AuthorizationStatus.DENY);
         boolean isResourceHandlerAvailableToHandleAuthorization = false;
-        if (StringUtils.isEmpty(authorizationContext.getPermissionString())) {
-            // If the permission string is empty then we check the registered available external resource handlers.
+        if (StringUtils.isEmpty(authorizationContext.getPermissionString()) && authorizationContext.getRequiredScopes().size() == 0) {
+            // If the permission string is empty or not scope is defined then we check the registered available
+            // external resource handlers.
             List<ResourceHandler> gettingExternalResourceHandlerList = AuthorizationServiceHolder.getInstance()
                     .getResourceHandlerList();
             List<ResourceHandler> externalResourceHandlers = HandlerManager.getInstance()

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.authz.valve;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -35,10 +36,13 @@ import org.wso2.carbon.identity.authz.service.exception.AuthzServiceServerExcept
 import org.wso2.carbon.identity.authz.valve.internal.AuthorizationValveServiceHolder;
 import org.wso2.carbon.identity.authz.valve.util.Utils;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_ALLOWED_SCOPES;
+import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_VALIDATE_SCOPE;
 
 /**
  * AuthenticationValve can be used to intercept any request.
@@ -77,9 +81,15 @@ public class AuthorizationValve extends ValveBase {
             if (resourceConfig != null && StringUtils.isNotEmpty(resourceConfig.getPermissions())) {
                 authorizationContext.setPermissionString(resourceConfig.getPermissions());
             }
+            if (resourceConfig != null && CollectionUtils.isNotEmpty(resourceConfig.getScopes())) {
+                authorizationContext.setRequiredScopes(resourceConfig.getScopes());
+            }
             authorizationContext.setContext(contextPath);
             authorizationContext.setHttpMethods(httpMethod);
             authorizationContext.setUser(authenticationContext.getUser());
+            authorizationContext.addParameter(OAUTH2_ALLOWED_SCOPES, authenticationContext.getParameter(OAUTH2_ALLOWED_SCOPES));
+            authorizationContext.addParameter(OAUTH2_VALIDATE_SCOPE, authenticationContext.getParameter(OAUTH2_VALIDATE_SCOPE));
+
             String tenantDomainFromURLMapping = Utils.getTenantDomainFromURLMapping(request);
             authorizationContext.setTenantDomainFromURLMapping(tenantDomainFromURLMapping);
             List<AuthorizationManager> authorizationManagerList = AuthorizationValveServiceHolder.getInstance()


### PR DESCRIPTION
https://github.com/wso2/productis/issues/6777

### Proposed changes in this pull request

Secure internal rest APIs with scopes. 

With this change, the resource authorizations in identity.xml will be as follows. So it will work only for the tokens retrieved with the given OAuth scope. Ex internal_consent_mgt_add

```
    <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/pii-categories(.*)" secured="true" http-method="POST">
            <Scopes>internal_consent_mgt_add</Scopes>
        </Resource>
        <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/pii-categories(.*)" secured="true" http-method="GET"/>
        <Resource context="(.*)/api/identity/consent-mgt/v1.0/consents/pii-categories(.+)" secured="true" http-method="DELETE">
            <Scopes>internal_consent_mgt_delete</Scopes>
        </Resource>
```

If it is required to work this with other authentication mechanisms (Ex basic Auth), it is required to add the permission tag as follows. 
      
```
  <Resource context="(.*)/api/identity/oauth2/dcr/v1.1/register(.*)" secured="true" http-method="POST">
            <Scopes>internal_application_mgt_create</Scopes>
            <Permissions>/permission/admin/manage/identity/applicationmgt/create</Permissions>
        </Resource>
```