### PR TITLE
Allow API calls on-behalf of associated accounts

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.service/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>org.wso2.carbon.identity.oauth</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.association.account</groupId>
+            <artifactId>org.wso2.carbon.identity.user.account.association</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
@@ -19,7 +19,8 @@
 package org.wso2.carbon.identity.auth.service.handler;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.http.HttpHeaders;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
@@ -28,10 +29,15 @@ import org.wso2.carbon.identity.auth.service.AuthenticationStatus;
 import org.wso2.carbon.identity.auth.service.exception.AuthClientException;
 import org.wso2.carbon.identity.auth.service.exception.AuthServerException;
 import org.wso2.carbon.identity.auth.service.exception.AuthenticationFailException;
+import org.wso2.carbon.identity.auth.service.internal.AuthenticationServiceHolder;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler;
-import org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.user.account.association.UserAccountConnector;
+import org.wso2.carbon.identity.user.account.association.dto.UserAccountAssociationDTO;
+import org.wso2.carbon.identity.user.account.association.exception.UserAccountAssociationException;
+import org.wso2.carbon.user.core.UserStoreConfigConstants;
+import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 /**
  * This is the abstract class for custom authentication handlers.
@@ -40,6 +46,9 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
  *
  */
 public abstract class AuthenticationHandler extends AbstractIdentityMessageHandler {
+
+    private static final Log log = LogFactory.getLog(AuthenticationHandler.class);
+    private static final String ASSOCIATED_USER_ID_HEADER = "AssociatedUserId";
 
     public int getPriority(MessageContext messageContext, int defaultValue) {
 
@@ -101,10 +110,127 @@ public abstract class AuthenticationHandler extends AbstractIdentityMessageHandl
 
                 if (user.getTenantDomain() != null && user.getTenantDomain().equalsIgnoreCase(PrivilegedCarbonContext
                         .getThreadLocalCarbonContext().getTenantDomain())) {
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(IdentityUtil.addDomainToName
-                            (user.getUserName(), user.getUserStoreDomain()));
+
+                    String domainAwareUserName = IdentityUtil.addDomainToName(user.getUserName(),
+                            user.getUserStoreDomain());
+                    String associatedUserRequestHeader = authenticationContext.getAuthenticationRequest().
+                            getHeader(ASSOCIATED_USER_ID_HEADER);
+                    if (StringUtils.isNotEmpty(associatedUserRequestHeader)) {
+                        User associatedUser = getAssociatedUser(authenticationResult, associatedUserRequestHeader);
+                        if (associatedUser != null && !isSameUser(user, associatedUser)) {
+                            setAssociatedUserInCarbonContext(user, associatedUser, authenticationResult);
+                            return;
+                        }
+                    }
+                    setUserInCarbonContext(domainAwareUserName);
                 }
             }
         }
+    }
+
+    private User getAssociatedUser(AuthenticationResult authenticationResult, String associatedUserRequestHeader) {
+
+        User associatedUser = getUser(associatedUserRequestHeader);
+        if (associatedUser == null) {
+            log.error("Invalid user provided with the header: " + ASSOCIATED_USER_ID_HEADER);
+            setFailedAuthentication(authenticationResult);
+            return null;
+        }
+        return associatedUser;
+    }
+
+    private void setAssociatedUserInCarbonContext(User user, User associatedUser,
+                                                  AuthenticationResult authenticationResult) {
+
+        if (isUsersInSameTenant(user, associatedUser)) {
+            UserAccountConnector userAccountConnector = AuthenticationServiceHolder.getInstance()
+                    .getUserAccountConnector();
+            if (userAccountConnector != null) {
+                try {
+                    UserAccountAssociationDTO[] userAccountAssociations = userAccountConnector
+                            .getAccountAssociationsOfUser(user.toFullQualifiedUsername());
+                    for (UserAccountAssociationDTO userAccountAssociationDTO : userAccountAssociations) {
+                        if (isSameUser(associatedUser, userAccountAssociationDTO)) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Setting the Associated user: " + associatedUser.toFullQualifiedUsername()
+                                        + ", sent with the header: "  + ASSOCIATED_USER_ID_HEADER + ", in the carbon " +
+                                        "context since it is a valid association of the user: "
+                                        + user.toFullQualifiedUsername());
+                            }
+                            setUserInCarbonContext(MultitenantUtils.getTenantAwareUsername(
+                                    associatedUser.toFullQualifiedUsername()));
+                            return;
+                        }
+                    }
+                    log.error("Associated user: " + associatedUser.toFullQualifiedUsername() + ", sent with the " +
+                            "header: "  + ASSOCIATED_USER_ID_HEADER + ", does not have a valid association with the " +
+                            "user: " + user.toFullQualifiedUsername());
+                    setFailedAuthentication(authenticationResult);
+                } catch (UserAccountAssociationException e) {
+                    log.error("Error while getting account associations of the user: "
+                            + user.toFullQualifiedUsername(), e);
+                    setFailedAuthentication(authenticationResult);
+                }
+            } else {
+                log.error("Unable to get the UserAccountConnector service");
+                setFailedAuthentication(authenticationResult);
+            }
+        } else {
+            log.error("Cannot switch to an Associated user: " + associatedUser.toFullQualifiedUsername() + ", " +
+                    "in a different tenant domain to the authenticated user: " + user.toFullQualifiedUsername());
+            setFailedAuthentication(authenticationResult);
+        }
+    }
+
+    private void setFailedAuthentication(AuthenticationResult authenticationResult) {
+
+        authenticationResult.setAuthenticationStatus(AuthenticationStatus.FAILED);
+    }
+
+    private boolean isUsersInSameTenant(User user, User associatedUser) {
+
+        return associatedUser.getTenantDomain().equals(user.getTenantDomain());
+    }
+
+    private boolean isSameUser(User user, UserAccountAssociationDTO userAccountAssociationDTO) {
+
+        User associatedUser = new User();
+        associatedUser.setTenantDomain(userAccountAssociationDTO.getTenantDomain());
+        associatedUser.setUserStoreDomain(userAccountAssociationDTO.getDomain());
+        associatedUser.setUserName(userAccountAssociationDTO.getUsername());
+        return isSameUser(user, associatedUser);
+    }
+
+    private boolean isSameUser(User firstUser, User secondUser) {
+
+        return firstUser.toFullQualifiedUsername().equals(secondUser.toFullQualifiedUsername());
+    }
+
+    private User getUser(String fullyQualifiedUserName) {
+
+        String realm = UserStoreConfigConstants.PRIMARY;
+        String tenantDomain = MultitenantUtils.getTenantDomain(fullyQualifiedUserName);
+        String username;
+        String[] strComponent = MultitenantUtils.getTenantAwareUsername(fullyQualifiedUserName).split("/");
+
+        if (strComponent.length == 1) {
+            username = strComponent[0];
+        } else if (strComponent.length == 2) {
+            realm = strComponent[0];
+            username = strComponent[1];
+        } else {
+            return null;
+        }
+
+        User user = new User();
+        user.setUserName(username);
+        user.setUserStoreDomain(realm);
+        user.setTenantDomain(tenantDomain);
+        return user;
+    }
+
+    private void setUserInCarbonContext(String domainAwareUserName) {
+
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(domainAwareUserName);
     }
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
@@ -34,8 +34,10 @@ import org.wso2.carbon.identity.auth.service.internal.AuthenticationServiceHolde
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.InitConfig;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import java.nio.charset.Charset;
@@ -97,9 +99,11 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
                 try {
                     int tenantId = IdentityTenantUtil.getTenantIdOfUser(userName);
                     String tenantDomain = MultitenantUtils.getTenantDomain(userName);
+                    String tenantAwareUsername = MultitenantUtils.getTenantAwareUsername(userName);
 
                     User user = new User();
-                    user.setUserName(MultitenantUtils.getTenantAwareUsername(userName));
+                    user.setUserName(UserCoreUtil.removeDomainFromName(tenantAwareUsername));
+                    user.setUserStoreDomain(IdentityUtil.extractDomainFromName(userName));
                     user.setTenantDomain(tenantDomain);
 
                     authenticationContext.setUser(user);

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientCertificateBasedAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientCertificateBasedAuthenticationHandler.java
@@ -34,6 +34,8 @@ import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.InitConfig;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -133,6 +135,7 @@ public class ClientCertificateBasedAuthenticationHandler extends AuthenticationH
                 }
                 if (StringUtils.isNotEmpty(username)) {
                     String tenantDomain = MultitenantUtils.getTenantDomain(username);
+                    String tenantAwareUserName = MultitenantUtils.getTenantAwareUsername(username);
 
                     // Get rid of the tenant domain name suffix, if the user belongs to the super tenant.
                     if (MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
@@ -145,7 +148,8 @@ public class ClientCertificateBasedAuthenticationHandler extends AuthenticationH
                     }
 
                     User user = new User();
-                    user.setUserName(username);
+                    user.setUserName(UserCoreUtil.removeDomainFromName(tenantAwareUserName));
+                    user.setUserStoreDomain(IdentityUtil.extractDomainFromName(username));
                     user.setTenantDomain(tenantDomain);
 
                     authenticationContext.setUser(user);

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -31,12 +31,14 @@ import org.wso2.carbon.identity.auth.service.AuthenticationStatus;
 import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.InitConfig;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientApplicationDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
 import javax.servlet.http.Cookie;
@@ -109,8 +111,12 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                 authenticationResult.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
 
                 if (StringUtils.isNotEmpty(responseDTO.getAuthorizedUser())) {
+                    String tenantAwareUserName = MultitenantUtils.getTenantAwareUsername(
+                            responseDTO.getAuthorizedUser());
+
                     User user = new User();
-                    user.setUserName(MultitenantUtils.getTenantAwareUsername(responseDTO.getAuthorizedUser()));
+                    user.setUserName(UserCoreUtil.removeDomainFromName(tenantAwareUserName));
+                    user.setUserStoreDomain(IdentityUtil.extractDomainFromName(responseDTO.getAuthorizedUser()));
                     user.setTenantDomain(MultitenantUtils.getTenantDomain(responseDTO.getAuthorizedUser()));
                     authenticationContext.setUser(user);
                 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/TomcatCookieAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/TomcatCookieAuthenticationHandler.java
@@ -29,6 +29,8 @@ import org.wso2.carbon.identity.auth.service.AuthenticationResult;
 import org.wso2.carbon.identity.auth.service.AuthenticationStatus;
 import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
@@ -110,8 +112,11 @@ public class TomcatCookieAuthenticationHandler extends AuthenticationHandler {
 
     private User buildUser(String userName, String tenantDomain) {
 
+        String tenantAwareUserName = MultitenantUtils.getTenantAwareUsername(userName);
+
         User user = new User();
-        user.setUserName(MultitenantUtils.getTenantAwareUsername(userName));
+        user.setUserName(UserCoreUtil.removeDomainFromName(tenantAwareUserName));
+        user.setUserStoreDomain(IdentityUtil.extractDomainFromName(userName));
         user.setTenantDomain(tenantDomain);
         return user;
     }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/internal/AuthenticationServiceComponent.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/internal/AuthenticationServiceComponent.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.auth.service.handler.impl.TomcatCookieAuthentica
 import org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil;
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
 import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
+import org.wso2.carbon.identity.user.account.association.UserAccountConnector;
 import org.wso2.carbon.user.core.service.RealmService;
 import java.util.Collections;
 import java.util.List;
@@ -108,6 +109,23 @@ public class AuthenticationServiceComponent {
 
     protected void removeAuthenticationHandler(AuthenticationHandler authenticationHandler) {
         AuthenticationServiceHolder.getInstance().getAuthenticationHandlers().remove(authenticationHandler);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.user.account.association.connector",
+            service = org.wso2.carbon.identity.user.account.association.UserAccountConnector.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "removeUserAccountConnector")
+    protected void addUserAccountConnector(UserAccountConnector userAccountConnector) {
+        if (log.isDebugEnabled()) {
+            log.debug("UserAccountConnector acquired");
+        }
+        AuthenticationServiceHolder.getInstance().setUserAccountConnector(userAccountConnector);
+    }
+
+    protected void removeUserAccountConnector(UserAccountConnector userAccountConnector) {
+        AuthenticationServiceHolder.getInstance().setUserAccountConnector(null);
     }
 
     @Reference(

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/internal/AuthenticationServiceHolder.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/internal/AuthenticationServiceHolder.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.auth.service.internal;
 import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.handler.ResourceHandler;
 import org.wso2.carbon.identity.core.handler.MessageHandlerComparator;
+import org.wso2.carbon.identity.user.account.association.UserAccountConnector;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.ArrayList;
@@ -38,7 +39,7 @@ public class AuthenticationServiceHolder {
     private RealmService realmService = null;
     private List<AuthenticationHandler> authenticationHandlers = new ArrayList<>();
     private List<ResourceHandler> resourceHandlers = new ArrayList<>();
-
+    private UserAccountConnector userAccountConnector = null;
 
     private AuthenticationServiceHolder() {
 
@@ -68,5 +69,15 @@ public class AuthenticationServiceHolder {
 
     public List<AuthenticationHandler> getAuthenticationHandlers() {
         return authenticationHandlers;
+    }
+
+    public UserAccountConnector getUserAccountConnector() {
+
+        return userAccountConnector;
+    }
+
+    public void setUserAccountConnector(UserAccountConnector userAccountConnector) {
+
+        this.userAccountConnector = userAccountConnector;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,12 @@
                 <version>${org.wso2.carbon.identity.oauth.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.association.account</groupId>
+                <artifactId>org.wso2.carbon.identity.user.account.association</artifactId>
+                <version>${org.wso2.carbon.identity.user.account.association.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.json.wso2</groupId>
                 <artifactId>json</artifactId>
                 <version>${json.wso2.version}</version>
@@ -354,6 +360,11 @@
         <org.wso2.carbon.identity.oauth.version>6.2.41</org.wso2.carbon.identity.oauth.version>
         <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 7.0.0)
         </org.wso2.carbon.identity.oauth.import.version.range>
+
+        <org.wso2.carbon.identity.user.account.association.version>5.3.5
+        </org.wso2.carbon.identity.user.account.association.version>
+        <org.wso2.carbon.identity.user.account.association.import.version.range>[5.3.5, 6.0.0)
+        </org.wso2.carbon.identity.user.account.association.import.version.range>
 
         <!-- OSGi framework component version -->
         <osgi.service.component.imp.pkg.version.range>[1.2.0, 2.0.0)</osgi.service.component.imp.pkg.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request
- Fixes https://github.com/wso2/product-is/issues/6882.
- Introduces a new header `AssociatedUserId`.
- The above-header will contain a fully qualified user name of a user(ex: SECONDARY/john@wso2.com).
- When a REST API call is made to the WSO2 IS, this PR ensures that, if the user represented by the above header has a valid association with the authenticated user, the REST API call will be done on behalf of the user represented by the header `AssociatedUserId`. 
- An example would be calling the SCIM `/me` endpoint of the user A, but authenticated as the user B, where users A and B are associated users.
