### PR TITLE
Set super tenant in context when request URI matches rewrite contexts configured

### DIFF
--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/RewriteContext.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/RewriteContext.java
@@ -25,13 +25,16 @@ public class RewriteContext {
 
     private String context;
 
-    private Pattern pattern;
+    private Pattern tenantContextPattern;
+
+    private Pattern baseContextPattern;
 
     public RewriteContext(boolean isWebApp, String context) {
 
         this.isWebApp = isWebApp;
         this.context = context;
-        this.pattern = Pattern.compile("/t/([^/]+)" + context);
+        this.tenantContextPattern = Pattern.compile("/t/([^/]+)" + context);
+        this.baseContextPattern = Pattern.compile(context);
     }
 
     public boolean isWebApp() {
@@ -54,13 +57,38 @@ public class RewriteContext {
         this.context = context;
     }
 
-    public Pattern getPattern() {
+    public Pattern getTenantContextPattern() {
 
-        return pattern;
+        return tenantContextPattern;
     }
 
+    public Pattern getBaseContextPattern() {
+
+        return baseContextPattern;
+    }
+
+    public void setTenantContextPattern(Pattern tenantContextPattern) {
+
+        this.tenantContextPattern = tenantContextPattern;
+    }
+
+    /**
+     * @deprecated as of release 1.4.1
+     * Replaced by getTenantContextPattern()
+     */
+    @Deprecated
+    public Pattern getPattern() {
+
+        return tenantContextPattern;
+    }
+
+    /**
+     * @deprecated as of release 1.4.1
+     * Replaced by setTenantContextPattern(Pattern tenantContextPattern)
+     */
+    @Deprecated
     public void setPattern(Pattern pattern) {
 
-        this.pattern = pattern;
+        this.tenantContextPattern = pattern;
     }
 }

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/RewriteContext.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/RewriteContext.java
@@ -33,8 +33,8 @@ public class RewriteContext {
 
         this.isWebApp = isWebApp;
         this.context = context;
-        this.tenantContextPattern = Pattern.compile("/t/([^/]+)" + context);
-        this.baseContextPattern = Pattern.compile(context);
+        this.tenantContextPattern = Pattern.compile("^/t/([^/]+)" + context);
+        this.baseContextPattern = Pattern.compile("^" + context);
     }
 
     public boolean isWebApp() {

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
@@ -25,6 +25,7 @@ import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.context.rewrite.bean.RewriteContext;
@@ -84,8 +85,8 @@ public class TenantContextRewriteValve extends ValveBase {
                 break;
             } else if (patternSuperTenant.matcher(requestURI).find() || patternSuperTenant.matcher(requestURI + "/")
                     .find()) {
-                String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-                IdentityUtil.threadLocalProperties.get().put(TENANT_NAME_FROM_CONTEXT, tenantDomain);
+                IdentityUtil.threadLocalProperties.get().put(TENANT_NAME_FROM_CONTEXT, MultitenantConstants
+                        .SUPER_TENANT_DOMAIN_NAME);
                 break;
             }
         }

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
@@ -72,7 +72,6 @@ public class TenantContextRewriteValve extends ValveBase {
         String contextToForward = null;
         boolean isContextRewrite = false;
         boolean isWebApp = false;
-        boolean isTenantDomainInThreadLocal = false;
 
         //Get the rewrite contexts and check whether request URI contains any of rewrite contains.
         for (RewriteContext context : contextsToRewrite) {
@@ -83,11 +82,11 @@ public class TenantContextRewriteValve extends ValveBase {
                 isWebApp = context.isWebApp();
                 contextToForward = context.getContext();
                 break;
-            } else if (!isTenantDomainInThreadLocal && patternSuperTenant.matcher(requestURI).find() ||
-                    patternSuperTenant.matcher(requestURI + "/").find()) {
+            } else if (patternSuperTenant.matcher(requestURI).find() || patternSuperTenant.matcher(requestURI + "/")
+                    .find()) {
                 String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
                 IdentityUtil.threadLocalProperties.get().put(TENANT_NAME_FROM_CONTEXT, tenantDomain);
-                isTenantDomainInThreadLocal = true;
+                break;
             }
         }
 

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
@@ -41,12 +41,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
+import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.TENANT_NAME_FROM_CONTEXT;
+
 public class TenantContextRewriteValve extends ValveBase {
 
-    private static final String TENANT_NAME_FROM_CONTEXT = "TenantNameFromContext";
     private static List<RewriteContext> contextsToRewrite;
     private static List<String> contextListToOverwriteDispatch;
     private TenantManager tenantManager;
@@ -60,6 +62,7 @@ public class TenantContextRewriteValve extends ValveBase {
         // Initialize the tenant context rewrite valve.
         contextsToRewrite = getContextsToRewrite();
         contextListToOverwriteDispatch = getContextListToOverwriteDispatchLocation();
+
     }
 
     @Override
@@ -69,15 +72,22 @@ public class TenantContextRewriteValve extends ValveBase {
         String contextToForward = null;
         boolean isContextRewrite = false;
         boolean isWebApp = false;
+        boolean isTenantDomainInThreadLocal = false;
 
         //Get the rewrite contexts and check whether request URI contains any of rewrite contains.
         for (RewriteContext context : contextsToRewrite) {
-            Pattern pattern = context.getPattern();
-            if (pattern.matcher(requestURI).find() || pattern.matcher(requestURI + "/").find()) {
+            Pattern patternTenant = context.getTenantContextPattern();
+            Pattern patternSuperTenant = context.getBaseContextPattern();
+            if (patternTenant.matcher(requestURI).find() || patternTenant.matcher(requestURI + "/").find()) {
                 isContextRewrite = true;
                 isWebApp = context.isWebApp();
                 contextToForward = context.getContext();
                 break;
+            } else if (!isTenantDomainInThreadLocal && patternSuperTenant.matcher(requestURI).find() ||
+                    patternSuperTenant.matcher(requestURI + "/").find()) {
+                String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+                IdentityUtil.threadLocalProperties.get().put(TENANT_NAME_FROM_CONTEXT, tenantDomain);
+                isTenantDomainInThreadLocal = true;
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -354,9 +354,9 @@
         <org.wso2.carbon.identity.context.rewrite.valve.version>${project.version}</org.wso2.carbon.identity.context.rewrite.valve.version>
 
         <!--Carbon identity version-->
-        <identity.framework.version>5.16.120</identity.framework.version>
+        <identity.framework.version>5.17.50</identity.framework.version>
         <carbon.identity.package.export.version>${identity.framework.version}</carbon.identity.package.export.version>
-        <carbon.identity.package.import.version.range>[5.14.67, 6.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.package.import.version.range>[5.17.8, 6.0.0)</carbon.identity.package.import.version.range>
 
         <org.wso2.carbon.identity.oauth.version>6.2.41</org.wso2.carbon.identity.oauth.version>
         <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 7.0.0)


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/8144
Relates to to wso2/carbon-identity-framework#2885

This fix sets the 'carbon.super' tenant in a thread local context,  that will be used to read the tenant in context, when the respect URIs are configured to have tenant domain in path and base path of such URIs are invoked

-

### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
