### PR TITLE
[public]Add contextual information to MDC for audit logs with fix

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.service/pom.xml
@@ -172,6 +172,7 @@
                             org.apache.axis2.*; version="${axis2.osgi.version.range}",
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
+                            org.slf4j; version="${org.slf4j.imp.pkg.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.osgi.util.tracker; version="${osgi.util.tracker.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHeaders;
+import org.slf4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
@@ -51,6 +52,7 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
 
     private static final Log log = LogFactory.getLog(BasicAuthenticationHandler.class);
     private final String BASIC_AUTH_HEADER = "Basic";
+    private final String USER_NAME = "userName";
 
     @Override
     public void init(InitConfig initConfig) {
@@ -129,6 +131,7 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
                                 if (log.isDebugEnabled()) {
                                     log.debug("Basic Authentication successful for the user: " + userName);
                                 }
+                                MDC.put(USER_NAME, userName);
                             }
                         } else {
                             String errorMessage = "Error occurred while trying to load the user realm for the tenant: " +

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHeaders;
+import org.apache.log4j.MDC;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.auth.service.AuthenticationRequest;
@@ -32,6 +33,7 @@ import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.InitConfig;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientApplicationDTO;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
@@ -46,7 +48,6 @@ import javax.servlet.http.Cookie;
 import static org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil.isAuthHeaderMatch;
 import static org.wso2.carbon.identity.auth.service.util.Constants.COOKIE_BASED_TOKEN_BINDING;
 import static org.wso2.carbon.identity.auth.service.util.Constants.COOKIE_BASED_TOKEN_BINDING_EXT_PARAM;
-
 import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_ALLOWED_SCOPES;
 import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_VALIDATE_SCOPE;
 
@@ -60,6 +61,7 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
     private static final Log log = LogFactory.getLog(OAuth2AccessTokenHandler.class);
     private final String OAUTH_HEADER = "Bearer";
     private final String CONSUMER_KEY = "consumer-key";
+    private final String SERVICE_PROVIDER = "serviceProvider";
 
     @Override
     protected AuthenticationResult doAuthenticate(MessageContext messageContext) {
@@ -124,6 +126,12 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                 authenticationContext.addParameter(OAUTH2_ALLOWED_SCOPES, responseDTO.getScope());
                 authenticationContext.addParameter(OAUTH2_VALIDATE_SCOPE,
                         AuthConfigurationUtil.getInstance().isScopeValidationEnabled());
+                try {
+                    MDC.put(SERVICE_PROVIDER,
+                            OAuth2Util.getServiceProvider(clientApplicationDTO.getConsumerKey()).getApplicationName());
+                } catch (IdentityOAuth2Exception e) {
+                    log.error("Error occurred while getting the Service Provider by Consumer key");
+                }
             }
         }
         return authenticationResult;

--- a/components/org.wso2.carbon.identity.auth.valve/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.valve/pom.xml
@@ -207,6 +207,7 @@
                             org.apache.axis2.*; version="${axis2.osgi.version.range}",
                             org.apache.commons.lang; version="${commons-lang.wso2.osgi.version.range}",
                             org.apache.commons.logging.*; version="${commons-logging.osgi.version.range}",
+                            org.slf4j; version="${org.slf4j.imp.pkg.version.range}",
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.osgi.util.tracker; version="${osgi.util.tracker.imp.pkg.version.range}",

--- a/pom.xml
+++ b/pom.xml
@@ -441,6 +441,7 @@
         <jacoco.version>0.7.9</jacoco.version>
         <maven.surefire.plugin.version>2.18.1</maven.surefire.plugin.version>
         <slf4j.api.version>1.5.5</slf4j.api.version>
+        <org.slf4j.imp.pkg.version.range>[1.5.5,2.0.0)</org.slf4j.imp.pkg.version.range>
         <powermock.version>1.7.4</powermock.version>
 
         <!-- Pax Logging Version -->


### PR DESCRIPTION
Resolves wso2/product-is#9119

Description
Added contextual information such as logged-in user, SP name, the remote IP address. Client user agent using MDC.

fix:
https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/118