### PR TITLE
Fix CORS valve issue with supportedHeaders parameter

### DIFF
--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/CORSValve.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/CORSValve.java
@@ -94,7 +94,7 @@ public class CORSValve extends ValveBase {
         } catch (CORSException e) {
             printMessage(e, response);
         } catch (CORSManagementServiceException e) {
-            log.error(e);
+            log.error("CORS management service error when intercepting an HTTP request.", e);
         }
     }
 
@@ -120,7 +120,7 @@ public class CORSValve extends ValveBase {
         out.println("CORS Valve: " + e.getMessage());
 
         if (log.isDebugEnabled()) {
-            log.debug(e);
+            log.debug("CORS valve error when intercepting an HTTP request.", e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/handler/CORSRequestHandler.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/handler/CORSRequestHandler.java
@@ -182,20 +182,14 @@ public class CORSRequestHandler {
             response.addHeader(Header.ACCESS_CONTROL_MAX_AGE, Integer.toString(config.getMaxAge()));
         }
 
-        String supportedMethods = HeaderUtils.serialize(config.getSupportedHeaders(), ", ");
+        String supportedMethods = HeaderUtils.serialize(config.getSupportedMethods(), ", ");
         response.addHeader(Header.ACCESS_CONTROL_ALLOW_METHODS, supportedMethods);
 
-        String supportedHeaders;
-        if (!config.isSupportAnyHeader()) {
-            supportedHeaders = HeaderUtils.serialize(config.getSupportedHeaders(), ", ");
-        } else {
-            supportedHeaders = null;
-        }
-
+        String supportedHeaders = HeaderUtils.serialize(config.getSupportedHeaders(), ", ");
         if (config.isSupportAnyHeader() && rawRequestHeadersString != null) {
-            // Echo author headers
+            // Echo author headers.
             response.addHeader(Header.ACCESS_CONTROL_ALLOW_HEADERS, rawRequestHeadersString);
-        } else if (supportedHeaders != null && !supportedHeaders.isEmpty()) {
+        } else if (!supportedHeaders.isEmpty()) {
             response.addHeader(Header.ACCESS_CONTROL_ALLOW_HEADERS, supportedHeaders);
         }
     }


### PR DESCRIPTION
### Proposed changes in this pull request

There is a bug in the CORS valve which prints out the `supportedHeaders` to the response instead of the `supportedMethods`. This PR fixes that issue. 

**Related:** https://github.com/wso2/product-is/issues/8551