### PR TITLE
Introduce a thread local to store current session identifier

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -35,4 +35,6 @@ public class Constants {
 
     public final static String COOKIE_BASED_TOKEN_BINDING = "cookie";
     public final static String COOKIE_BASED_TOKEN_BINDING_EXT_PARAM = "atbv";
+
+    public final static String CURRENT_SESSION_IDENTIFIER = "currentSessionIdentifier";
 }

--- a/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java
+++ b/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java
@@ -144,6 +144,8 @@ public class AuthenticationValve extends ValveBase {
 
             // Clear thread local service provider info.
             unsetThreadLocalServiceProvider();
+            // Clear thread local current session id.
+            unsetCurrentSessionIdThreadLocal();
         }
 
 
@@ -201,5 +203,15 @@ public class AuthenticationValve extends ValveBase {
             return claimsFilters.contains(param);
         }
         return false;
+    }
+
+    /**
+     * Remove current session id from thread local, which is set in OAuth2AccessTokenHandler.
+     */
+    private void unsetCurrentSessionIdThreadLocal() {
+
+        if (IdentityUtil.threadLocalProperties.get().get(Constants.CURRENT_SESSION_IDENTIFIER) != null) {
+            IdentityUtil.threadLocalProperties.get().remove(Constants.CURRENT_SESSION_IDENTIFIER);
+        }
     }
 }


### PR DESCRIPTION
This PR introduces a thread local to store current session identifier extracted from the token binding which is required when skipping the current session from being terminated at certain scenarios - i.e. password update via scim/me API

Resolves : https://github.com/wso2/product-is/issues/9461