### PR TITLE
Set service provider info to provisioning SP thread local

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -69,7 +69,6 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
     private final String SERVICE_PROVIDER = "serviceProvider";
     private final String SERVICE_PROVIDER_TENANT_DOMAIN = "serviceProviderTenantDomain";
     private final String SCIM_ME_ENDPOINT_URI = "scim2/me";
-    private final String DEFAULT_SCIM2_DIALECT = "urn:ietf:params:scim:schemas:core:2.0";
 
     @Override
     protected AuthenticationResult doAuthenticate(MessageContext messageContext) {
@@ -305,7 +304,6 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                     new ThreadLocalProvisioningServiceProvider();
             provisioningServiceProvider.setServiceProviderName(oauthAppConsumerKey);
             provisioningServiceProvider.setServiceProviderType(ProvisioningServiceProviderType.OAUTH);
-            provisioningServiceProvider.setClaimDialect(DEFAULT_SCIM2_DIALECT);
             provisioningServiceProvider.setTenantDomain(serviceProviderTenantDomain);
             IdentityApplicationManagementUtil.setThreadLocalProvisioningServiceProvider(provisioningServiceProvider);
         }

--- a/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java
+++ b/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.slf4j.MDC;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.auth.service.AuthenticationManager;
 import org.wso2.carbon.identity.auth.service.AuthenticationRequest;
@@ -146,6 +147,8 @@ public class AuthenticationValve extends ValveBase {
             unsetThreadLocalServiceProvider();
             // Clear thread local current session id.
             unsetCurrentSessionIdThreadLocal();
+            // Clear thread local provisioning service provider.
+            IdentityApplicationManagementUtil.resetThreadLocalProvisioningServiceProvider();
         }
 
 


### PR DESCRIPTION
### Proposed changes in this pull request

This PR sets service provider information to the `ThreadLocalProvisioningServiceProvider` so that the SP information are available to the provisioning framework.

Resolves : https://github.com/wso2/product-is/issues/10279