### PR TITLE
Remove deprecated method usage and use the alternative new method for token validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,7 +401,7 @@
         <carbon.identity.package.export.version>${identity.framework.version}</carbon.identity.package.export.version>
         <carbon.identity.package.import.version.range>[5.17.8, 6.0.0)</carbon.identity.package.import.version.range>
 
-        <org.wso2.carbon.identity.oauth.version>6.4.56</org.wso2.carbon.identity.oauth.version>
+        <org.wso2.carbon.identity.oauth.version>6.4.149</org.wso2.carbon.identity.oauth.version>
         <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 7.0.0)
         </org.wso2.carbon.identity.oauth.import.version.range>
 


### PR DESCRIPTION
The curent Oauth2 method we use to validate the access token in Oauth2AccessTokenHnadler is `findOAuthConsumerIfTokenIsValid(OAuth2TokenValidationRequestDTO requestDTO)`. It uses a deprecated method[1] underneath. Also this deprecated method unnecessarily generates a jwt token during the token introspection flow. Therefore, this PR is to change the token introspection method to the new methos to be used instead of the deprecated method.

Related to : https://github.com/wso2/product-is/issues/9616
Partially resolves : https://github.com/wso2/product-is/issues/11257
Depends on : https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1549

[1] https://github.com/wso2-extensions/identity-inbound-auth-oauth/blob/c3340e3eb8132b1f941a42ba3fc32259f3408260/components/org.wso2.carbon.identity.oauth/src/main/java/org/wso2/carbon/identity/oauth2/validators/TokenValidationHandler.java#L152
