### PR TITLE
Enable client authentication for introspection endpoint.

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationContext.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationContext.java
@@ -67,7 +67,7 @@ public class AuthenticationContext extends MessageContext {
         return properties.get(key);
     }
 
-    public void setProperty(String key, Object value) {
+    public void addProperty(String key, Object value) {
 
         this.properties.put(key, value);
     }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationContext.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationContext.java
@@ -62,12 +62,12 @@ public class AuthenticationContext extends MessageContext {
         this.user = user;
     }
 
-    public Object getProperties(String key) {
+    public Object getProperty(String key) {
 
         return properties.get(key);
     }
 
-    public void setProperties(String key, Object value) {
+    public void setProperty(String key, Object value) {
 
         this.properties.put(key, value);
     }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationContext.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationContext.java
@@ -23,6 +23,8 @@ import org.wso2.carbon.identity.auth.service.exception.AuthRuntimeException;
 import org.wso2.carbon.identity.auth.service.module.ResourceConfig;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * AuthenticationContext which is pass across the authentication flow.
@@ -32,6 +34,7 @@ public class AuthenticationContext extends MessageContext {
     private AuthenticationResult authenticationResult = null;
     private ResourceConfig resourceConfig = null;
     private User user = null;
+    private Map<Object, Object> properties = new HashMap<>();
 
     /**
      * @param authenticationRequest
@@ -57,6 +60,16 @@ public class AuthenticationContext extends MessageContext {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    public Object getProperties(String key) {
+
+        return properties.get(key);
+    }
+
+    public void setProperties(String key, Object value) {
+
+        this.properties.put(key, value);
     }
 
     public ResourceConfig getResourceConfig() {

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationContext.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationContext.java
@@ -34,7 +34,7 @@ public class AuthenticationContext extends MessageContext {
     private AuthenticationResult authenticationResult = null;
     private ResourceConfig resourceConfig = null;
     private User user = null;
-    private Map<Object, Object> properties = new HashMap<>();
+    private Map<String, Object> properties = new HashMap<>();
 
     /**
      * @param authenticationRequest

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
@@ -87,7 +87,7 @@ public class BasicClientAuthenticationHandler extends AuthenticationHandler {
         String authorizationHeader = authenticationContext.getAuthenticationRequest().
                 getHeader(HttpHeaders.AUTHORIZATION);
 
-        if (authorizationHeader != null){
+        if (authorizationHeader != null) {
             String[] splitAuthorizationHeader = authorizationHeader.split(" ");
             if (splitAuthorizationHeader.length == 2) {
                 byte[] decodedAuthHeader = Base64.decodeBase64(splitAuthorizationHeader[1].getBytes());

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
@@ -105,7 +105,7 @@ public class BasicClientAuthenticationHandler extends AuthenticationHandler {
                                     + " with client secret.");
                         }
 
-                        authenticationContext.setProperties(Constants.AUTH_CONTEXT_OAUTH_APP_PROPERTY,
+                        authenticationContext.setProperty(Constants.AUTH_CONTEXT_OAUTH_APP_PROPERTY,
                                 OAuth2Util.getAppInformationByClientId(clientId));
 
                         if (OAuth2Util.authenticateClient(clientId, clientSecret)) {

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.auth.service.handler.impl;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHeaders;
+import org.wso2.carbon.identity.auth.service.AuthenticationContext;
+import org.wso2.carbon.identity.auth.service.AuthenticationResult;
+import org.wso2.carbon.identity.auth.service.AuthenticationStatus;
+import org.wso2.carbon.identity.auth.service.exception.AuthenticationFailException;
+import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.handler.InitConfig;
+import org.wso2.carbon.identity.oauth.IdentityOAuthAdminException;
+import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+
+import java.nio.charset.Charset;
+
+import static org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil.isAuthHeaderMatch;
+
+/**
+ * BasicAuthenticationHandler is for authenticate the request based on Basic Authentication.
+ * canHandle method will confirm whether this request can be handled by this authenticator or not.
+ */
+public class BasicClientAuthenticationHandler extends AuthenticationHandler {
+
+    private static final Log log = LogFactory.getLog(BasicClientAuthenticationHandler.class);
+    private final String BASIC_AUTH_HEADER = "Basic";
+
+    @Override
+    public void init(InitConfig initConfig) {
+
+    }
+
+    @Override
+    public String getName() {
+
+        return "BasicClientAuthenticationHandler";
+    }
+
+    @Override
+    public int getPriority(MessageContext messageContext) {
+
+        return getPriority(messageContext, 99);
+    }
+
+    @Override
+    public boolean canHandle(MessageContext messageContext) {
+
+        return isAuthHeaderMatch(messageContext, BASIC_AUTH_HEADER);
+    }
+
+    @Override
+    public boolean isEnabled(MessageContext messageContext) {
+
+        return true;
+    }
+
+    @Override
+    protected AuthenticationResult doAuthenticate(MessageContext messageContext) throws AuthenticationFailException {
+
+        AuthenticationResult authenticationResult = new AuthenticationResult(AuthenticationStatus.FAILED);
+        AuthenticationContext authenticationContext = (AuthenticationContext) messageContext;
+        String authorizationHeader = authenticationContext.getAuthenticationRequest().
+                getHeader(HttpHeaders.AUTHORIZATION);
+
+        String[] splitAuthorizationHeader = authorizationHeader.split(" ");
+        if (splitAuthorizationHeader.length == 2) {
+            byte[] decodedAuthHeader = Base64.decodeBase64(splitAuthorizationHeader[1].getBytes());
+            String authHeader = new String(decodedAuthHeader, Charset.defaultCharset());
+            String[] splitCredentials = authHeader.split(":", 2);
+
+            if (splitCredentials.length == 2 && StringUtils.isNotBlank(splitCredentials[0]) &&
+                    StringUtils.isNotBlank(splitCredentials[1])) {
+                String clientId = splitCredentials[0];
+                String clientSecret = splitCredentials[1];
+
+                try {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Authenticating client : " + clientId + " with client " + "secret.");
+                    }
+                    if (OAuth2Util.authenticateClient(clientId, clientSecret)) {
+                        authenticationResult.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
+                    }
+                } catch (IdentityOAuthAdminException e) {
+                    String errorMessage = "Error while authenticating " + clientId;
+                    log.error(errorMessage);
+                    throw new AuthenticationFailException(errorMessage, e);
+                } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
+                    String errorMessage = "Invalid client : " + clientId;
+                    log.error(errorMessage);
+                    throw new AuthenticationFailException(errorMessage, e);
+                }
+            } else {
+                String errorMessage = "Error occurred while trying to authenticate. The auth application credentials "
+                        + "are not defined correctly.";
+                log.error(errorMessage);
+                throw new AuthenticationFailException(errorMessage);
+            }
+        } else {
+            String errorMessage = "Error occurred while trying to authenticate. The " + HttpHeaders.AUTHORIZATION +
+                    " header values are not defined correctly.";
+            log.error(errorMessage);
+            throw new AuthenticationFailException(errorMessage);
+        }
+        return authenticationResult;
+    }
+}

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
@@ -105,7 +105,7 @@ public class BasicClientAuthenticationHandler extends AuthenticationHandler {
                                     + " with client secret.");
                         }
 
-                        authenticationContext.setProperty(Constants.AUTH_CONTEXT_OAUTH_APP_PROPERTY,
+                        authenticationContext.addProperty(Constants.AUTH_CONTEXT_OAUTH_APP_PROPERTY,
                                 OAuth2Util.getAppInformationByClientId(clientId));
 
                         if (OAuth2Util.authenticateClient(clientId, clientSecret)) {

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
@@ -108,11 +108,11 @@ public class BasicClientAuthenticationHandler extends AuthenticationHandler {
                             authenticationResult.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
                         }
                     } catch (IdentityOAuthAdminException e) {
-                        String errorMessage = "Error while authenticating application with client ID : " + clientId;
+                        String errorMessage = "Error while authenticating application with client ID: " + clientId;
                         log.error(errorMessage, e);
                         throw new AuthenticationFailException(errorMessage, e);
                     } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
-                        String errorMessage = "Invalid client : " + clientId;
+                        String errorMessage = "Invalid client: " + clientId;
                         log.error(errorMessage, e);
                         throw new AuthenticationFailException(errorMessage, e);
                     }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.auth.service.AuthenticationResult;
 import org.wso2.carbon.identity.auth.service.AuthenticationStatus;
 import org.wso2.carbon.identity.auth.service.exception.AuthenticationFailException;
 import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
+import org.wso2.carbon.identity.auth.service.util.Constants;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.InitConfig;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
@@ -61,7 +62,7 @@ public class BasicClientAuthenticationHandler extends AuthenticationHandler {
     @Override
     public String getName() {
 
-        return "BasicClientAuthentication";
+        return Constants.BASIC_CLIENT_AUTH_HANDLER;
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/internal/AuthenticationServiceComponent.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/internal/AuthenticationServiceComponent.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.auth.service.factory.AuthenticationRequestBuilde
 import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.handler.ResourceHandler;
 import org.wso2.carbon.identity.auth.service.handler.impl.BasicAuthenticationHandler;
+import org.wso2.carbon.identity.auth.service.handler.impl.BasicClientAuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.handler.impl.ClientAuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.handler.impl.ClientCertificateBasedAuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.handler.impl.OAuth2AccessTokenHandler;
@@ -57,6 +58,7 @@ public class AuthenticationServiceComponent {
             cxt.getBundleContext().registerService(AuthenticationHandler.class, new ClientCertificateBasedAuthenticationHandler(), null);
             cxt.getBundleContext().registerService(AuthenticationHandler.class, new ClientAuthenticationHandler(), null);
             cxt.getBundleContext().registerService(AuthenticationHandler.class, new TomcatCookieAuthenticationHandler(), null);
+            cxt.getBundleContext().registerService(AuthenticationHandler.class, new BasicClientAuthenticationHandler(), null);
             cxt.getBundleContext().registerService(AuthenticationManager.class, AuthenticationManager.getInstance(), null);
             cxt.getBundleContext().registerService(AuthenticationRequestBuilderFactory.class, AuthenticationRequestBuilderFactory.getInstance(), null);
             AuthConfigurationUtil.getInstance().buildResourceAccessControlData();

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
@@ -149,7 +149,7 @@ public class AuthConfigurationUtil {
                     AuthenticationServiceHolder.getInstance().getAuthenticationHandlers();
             for (AuthenticationHandler handler : allAvailableAuthHandlers) {
                 String handlerName = handler.getName();
-                if (handlerName.equals("BasicClientAuthenticationHandler")){
+                if (handlerName.equals(Constants.BASIC_CLIENT_AUTH_HANDLER)) {
                     continue;
                 }
                 allowedAuthHandlersList.add(handlerName);

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
@@ -148,7 +148,11 @@ public class AuthConfigurationUtil {
             List<AuthenticationHandler> allAvailableAuthHandlers =
                     AuthenticationServiceHolder.getInstance().getAuthenticationHandlers();
             for (AuthenticationHandler handler : allAvailableAuthHandlers) {
-                allowedAuthHandlersList.add(handler.getName());
+                String handlerName = handler.getName();
+                if (handlerName.equals("BasicClientAuthenticationHandler")){
+                    continue;
+                }
+                allowedAuthHandlersList.add(handlerName);
             }
         } else {
             String regex = "\\s*,\\s*";

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
@@ -149,7 +149,7 @@ public class AuthConfigurationUtil {
                     AuthenticationServiceHolder.getInstance().getAuthenticationHandlers();
             for (AuthenticationHandler handler : allAvailableAuthHandlers) {
                 String handlerName = handler.getName();
-                if (handlerName.equals(Constants.BASIC_CLIENT_AUTH_HANDLER)) {
+                if (Constants.BASIC_CLIENT_AUTH_HANDLER.equals(handlerName)) {
                     continue;
                 }
                 allowedAuthHandlersList.add(handlerName);

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -39,4 +39,6 @@ public class Constants {
     public final static String CURRENT_SESSION_IDENTIFIER = "currentSessionIdentifier";
 
     public final static String BASIC_CLIENT_AUTH_HANDLER = "BasicClientAuthentication";
+
+    public final static String AUTH_CONTEXT_OAUTH_APP_PROPERTY = "oAuthAppDO";
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -38,5 +38,5 @@ public class Constants {
 
     public final static String CURRENT_SESSION_IDENTIFIER = "currentSessionIdentifier";
 
-    public final static String BASIC_CLIENT_AUTH_HANDLER = "BasicClientAuthenticationHandler";
+    public final static String BASIC_CLIENT_AUTH_HANDLER = "BasicClientAuthentication";
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -37,4 +37,6 @@ public class Constants {
     public final static String COOKIE_BASED_TOKEN_BINDING_EXT_PARAM = "atbv";
 
     public final static String CURRENT_SESSION_IDENTIFIER = "currentSessionIdentifier";
+
+    public final static String BASIC_CLIENT_AUTH_HANDLER = "BasicClientAuthenticationHandler";
 }

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -152,6 +152,6 @@ public class AuthorizationValve extends ValveBase {
 
     private boolean isClientEmpty(AuthenticationContext authenticationContext) {
 
-        return authenticationContext.getProperties(Constants.AUTH_CONTEXT_OAUTH_APP_PROPERTY) == null;
+        return authenticationContext.getProperty(Constants.AUTH_CONTEXT_OAUTH_APP_PROPERTY) == null;
     }
 }

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.authz.valve.util;
 import org.apache.catalina.connector.Request;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
+import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 public class Utils {
@@ -52,7 +54,14 @@ public class Utils {
 
         String tenantDomainFromURLMapping = getTenantDomainFromURLMapping(request);
         User user = authenticationContext.getUser();
-        String userDomain = user.getTenantDomain();
-        return tenantDomainFromURLMapping.equals(userDomain);
+
+        String tenantDomain;
+        if (user != null) {
+            tenantDomain = user.getTenantDomain();
+        } else {
+            OAuthAppDO oAuthAppDO = (OAuthAppDO) authenticationContext.getProperties("oAuthAppDO");
+            tenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
+        }
+        return tenantDomainFromURLMapping.equals(tenantDomain);
     }
 }

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.authz.valve.util;
 import org.apache.catalina.connector.Request;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
+import org.wso2.carbon.identity.auth.service.util.Constants;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -59,7 +60,8 @@ public class Utils {
         if (user != null) {
             tenantDomain = user.getTenantDomain();
         } else {
-            OAuthAppDO oAuthAppDO = (OAuthAppDO) authenticationContext.getProperties("oAuthAppDO");
+            OAuthAppDO oAuthAppDO = (OAuthAppDO) authenticationContext.getProperty(
+                    Constants.AUTH_CONTEXT_OAUTH_APP_PROPERTY);
             tenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
         }
         return tenantDomainFromURLMapping.equals(tenantDomain);


### PR DESCRIPTION
Create a new authentication BasicClientAuthenticationHandler which extend the AuthenticationHandler class to authenticate requests using client credentials. New authentication handler will not be available as a default handler, need to configure per endpoint from identity.xml to use it and has  a high priority than the Basic authentication handler.