### PR TITLE
Add support for multitenant users at ClientCertificateBasedAuthenticationHandler

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientCertificateBasedAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientCertificateBasedAuthenticationHandler.java
@@ -148,7 +148,7 @@ public class ClientCertificateBasedAuthenticationHandler extends AuthenticationH
                     username = UserCoreUtil.removeDomainFromName(username);
 
                     User user = new User();
-                    user.setUserName(username);
+                    user.setUserName(MultitenantUtils.getTenantAwareUsername(username));
                     user.setTenantDomain(tenantDomain);
                     user.setUserStoreDomain(userStoreDomain);
 


### PR DESCRIPTION
### Proposed changes in this pull request

- Previous implementation does not support multi tenant users with this fix multi tenant users will be supported at the CleintCertificateBasedAuthenticationHandler. 
- Fixes: https://github.com/wso2/product-is/issues/12303 

### Follow up actions

- Upgrade the product-is to the released version (after this PR is merged).
