### PR TITLE
Remove client errors logged in ERROR log level

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicAuthenticationHandler.java
@@ -183,13 +183,11 @@ public class BasicAuthenticationHandler extends AuthenticationHandler {
             } else {
                 String errorMessage = "Error occurred while trying to authenticate. The auth user credentials " +
                         "are not defined correctly.";
-                log.error(errorMessage);
                 throw new AuthenticationFailException(errorMessage);
             }
         } else {
             String errorMessage = "Error occurred while trying to authenticate. The " + HttpHeaders.AUTHORIZATION +
                     " header values are not defined correctly.";
-            log.error(errorMessage);
             throw new AuthenticationFailException(errorMessage);
         }
         return authenticationResult;


### PR DESCRIPTION
Resolves https://github.com/wso2/product-is/issues/13344

This PR removes client errors logged in the ERROR log level. These errors should be logged at debug level. The errors are already being properly logged through [1][2] at the finally handling place.

[1] - https://github.com/wso2-extensions/identity-carbon-auth-rest/blob/master/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java#L149-L166
[2] - https://github.com/wso2-extensions/identity-carbon-auth-rest/blob/master/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/util/APIErrorResponseHandler.java