### PR TITLE
Switch for logging facades

### DIFF
--- a/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/util/APIErrorResponseHandler.java
+++ b/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/util/APIErrorResponseHandler.java
@@ -26,7 +26,7 @@ import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-import org.apache.logging.log4j.ThreadContext;
+import org.slf4j.MDC;
 
 /**
  * APIErrorResponseHandler handles the authentications and authorizations error responses.
@@ -163,7 +163,7 @@ public class APIErrorResponseHandler {
             jsonObject.put("description", errorDescription);
         }
         if (isCorrelationIDPresent()) {
-            jsonObject.put("traceId", ThreadContext.get(CORRELATION_ID_MDC));
+            jsonObject.put("traceId", MDC.get(CORRELATION_ID_MDC));
         }
         setResponseBody(response, jsonObject);
     }
@@ -193,7 +193,7 @@ public class APIErrorResponseHandler {
             jsonObject.put("description", errorDescription);
         }
         if (isCorrelationIDPresent()) {
-            jsonObject.put("traceId", ThreadContext.get(CORRELATION_ID_MDC));
+            jsonObject.put("traceId", MDC.get(CORRELATION_ID_MDC));
         }
         setResponseBody(response, jsonObject);
     }
@@ -204,6 +204,6 @@ public class APIErrorResponseHandler {
     }
 
     private static boolean isCorrelationIDPresent() {
-        return ThreadContext.get(CORRELATION_ID_MDC) != null;
+        return MDC.get(CORRELATION_ID_MDC) != null;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

Switch for logging facade instead of concrete implementations like log4j2. Then it would be easy to switch between logging frameworks based on necessity without any code changes.