### PR TITLE
Return 403 if org level authz failed and unable to authorize using old authz model too

### DIFF
--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -53,6 +53,7 @@ import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_VALIDA
 public class AuthorizationValve extends ValveBase {
 
     private static final String AUTH_CONTEXT = "auth-context";
+    private static final String ORGANIZATION_PATH_PARAM = "/o/";
 
     private static final Log log = LogFactory.getLog(AuthorizationValve.class);
 
@@ -70,8 +71,7 @@ public class AuthorizationValve extends ValveBase {
             }
 
             String requestURI = request.getRequestURI();
-            String organizationPathParam = "/o/";
-            if (requestURI.startsWith(organizationPathParam)) {
+            if (requestURI.startsWith(ORGANIZATION_PATH_PARAM)) {
                 AuthorizationResult authorizationResult =
                         authorizeInOrganizationLevel(request, response, authenticationContext, resourceConfig,
                                 authorizationContext);
@@ -89,7 +89,7 @@ public class AuthorizationValve extends ValveBase {
                 Forbidden the /o/<org-id> path requests if the org level authz failed and
                 resource is not cross tenant allowed or authenticated user doesn't belong to the accessed resource's org.
                  */
-                if (requestURI.startsWith(organizationPathParam)) {
+                if (requestURI.startsWith(ORGANIZATION_PATH_PARAM)) {
                     APIErrorResponseHandler.handleErrorResponse(authenticationContext, response,
                             HttpServletResponse.SC_FORBIDDEN, null);
                     return;

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -84,6 +84,15 @@ public class AuthorizationValve extends ValveBase {
             }
             // If user didn't authorized via org level authz model, fallback to old authz model.
             if (!isRequestValidForTenant(authenticationContext, authorizationContext, request)) {
+                /*
+                Forbidden the /o/<org-id> path requests if the org level authz failed and
+                resource is not cross tenant allowed or authenticated user doesn't belong to the accessed resource's org.
+                 */
+                if (requestURI.startsWith("/o/")) {
+                    APIErrorResponseHandler.handleErrorResponse(authenticationContext, response,
+                            HttpServletResponse.SC_FORBIDDEN, null);
+                    return;
+                }
                 if (log.isDebugEnabled()) {
                     log.debug("Authorization to " + request.getRequestURI()
                             + " is denied because the authenticated user belongs to different tenant domain: "

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -70,7 +70,8 @@ public class AuthorizationValve extends ValveBase {
             }
 
             String requestURI = request.getRequestURI();
-            if (requestURI.startsWith("/o/")) {
+            String organizationPathParam = "/o/";
+            if (requestURI.startsWith(organizationPathParam)) {
                 AuthorizationResult authorizationResult =
                         authorizeInOrganizationLevel(request, response, authenticationContext, resourceConfig,
                                 authorizationContext);
@@ -88,7 +89,7 @@ public class AuthorizationValve extends ValveBase {
                 Forbidden the /o/<org-id> path requests if the org level authz failed and
                 resource is not cross tenant allowed or authenticated user doesn't belong to the accessed resource's org.
                  */
-                if (requestURI.startsWith("/o/")) {
+                if (requestURI.startsWith(organizationPathParam)) {
                     APIErrorResponseHandler.handleErrorResponse(authenticationContext, response,
                             HttpServletResponse.SC_FORBIDDEN, null);
                     return;


### PR DESCRIPTION
### Proposed changes in this pull request
Fix https://github.com/wso2-extensions/identity-organization-management/issues/61
Now such requests return 403 with following response boday
```
{
    "traceId": "cc350f59-c08a-4569-bd21-dff63095bca8",
    "code": 403,
    "description": "Operation is not permitted. You do not have permissions to make this request.",
    "message": "Forbidden"
}
```

