### PR TITLE
Restrict using token obtained from different org for another tenant API call

### DIFF
--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -168,8 +168,7 @@ public class AuthorizationValve extends ValveBase {
 
     private AuthorizationResult authorizeInOrganizationLevel(Request request, Response response,
                                                              AuthenticationContext authenticationContext,
-                                                             ResourceConfig resourceConfig)
-            throws IOException {
+                                                             ResourceConfig resourceConfig) throws IOException {
 
         AuthorizationResult authorizationResult = new AuthorizationResult(AuthorizationStatus.DENY);
 

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -76,9 +76,25 @@ public class AuthorizationValve extends ValveBase {
             String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
             if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenantDomain) &&
                     requestURI.startsWith(ORGANIZATION_PATH_PARAM)) {
+                /*
+                If the request is authenticated using an oauth2 access token and scope validation is required,
+                the token obtained tenant domain should be equal to the accessed resource's tenant domain.
+                 */
+                Object scopeValidationEnabled = authenticationContext.getParameter(OAUTH2_VALIDATE_SCOPE);
+                if (scopeValidationEnabled != null && Boolean.parseBoolean(scopeValidationEnabled.toString())) {
+                    if (!Utils.isUserBelongsToRequestedTenant(authenticationContext, request)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Authorization to " + request.getRequestURI() +
+                                    " is denied because the used access token issued from a different tenant domain: " +
+                                    authenticationContext.getUser().getTenantDomain());
+                        }
+                        APIErrorResponseHandler.handleErrorResponse(authenticationContext, response,
+                                HttpServletResponse.SC_UNAUTHORIZED, null);
+                        return;
+                    }
+                }
                 AuthorizationResult authorizationResult =
-                        authorizeInOrganizationLevel(request, response, authenticationContext, resourceConfig,
-                                authorizationContext);
+                        authorizeInOrganizationLevel(request, response, authenticationContext, resourceConfig);
                 /*
                 If the user authorized from organization level permissions, grant access and execute next valve.
                  */
@@ -151,8 +167,8 @@ public class AuthorizationValve extends ValveBase {
     }
 
     private AuthorizationResult authorizeInOrganizationLevel(Request request, Response response,
-                                              AuthenticationContext authenticationContext,
-                                              ResourceConfig resourceConfig, AuthorizationContext authorizationContext)
+                                                             AuthenticationContext authenticationContext,
+                                                             ResourceConfig resourceConfig)
             throws IOException {
 
         AuthorizationResult authorizationResult = new AuthorizationResult(AuthorizationStatus.DENY);


### PR DESCRIPTION
### Proposed changes in this pull request
When accessing REST APIs in `o/<orgid>/` path:
a user who resides in a cross-organization would be able to access another organization resource if the user has relevant permissions against the accessed resource's org.

But if scope validation is required, the REST APIs accessed with `o/<orgid>` should be authenticated with a token obtained in the same organization.