### PR TITLE
Set current access token id to the threadlocal to use in the password reset

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -50,6 +50,8 @@ import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 
+import java.util.Optional;
+
 import static org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil.isAuthHeaderMatch;
 import static org.wso2.carbon.identity.auth.service.util.Constants.IDP_NAME;
 import static org.wso2.carbon.identity.auth.service.util.Constants.IS_FEDERATED_USER;
@@ -113,10 +115,9 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                 }
 
                 // If the request is coming to me endpoint, store the token id to the thread local.
-                if (authenticationRequest.getRequest() != null
-                        && authenticationRequest.getRequest().getRequestURI() != null
-                        && authenticationRequest.getRequest().getRequestURI()
-                        .toLowerCase().endsWith(SCIM_ME_ENDPOINT_URI) && accessToken != null) {
+                if (Optional.ofNullable(authenticationRequest.getRequest()).map(Request::getRequestURI)
+                        .filter(u -> u.toLowerCase().endsWith(SCIM_ME_ENDPOINT_URI)).isPresent()
+                        && accessToken != null) {
                     setCurrentTokenIdThreadLocal(getTokenIdFromAccessToken(accessToken));
                 }
 

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpHeaders;
 import org.slf4j.MDC;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.model.ProvisioningServiceProviderType;
 import org.wso2.carbon.identity.application.common.model.ThreadLocalProvisioningServiceProvider;
 import org.wso2.carbon.identity.application.common.model.User;
@@ -109,6 +110,14 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
 
                 if (!oAuth2IntrospectionResponseDTO.isActive()) {
                     return authenticationResult;
+                }
+
+                // If the request is coming to me endpoint, store the token id to the thread local.
+                if (authenticationRequest.getRequest() != null
+                        && authenticationRequest.getRequest().getRequestURI() != null
+                        && authenticationRequest.getRequest().getRequestURI()
+                        .toLowerCase().endsWith(SCIM_ME_ENDPOINT_URI) && accessToken != null) {
+                    setCurrentTokenIdThreadLocal(getTokenIdFromAccessToken(accessToken));
                 }
 
                 TokenBinding tokenBinding = new TokenBinding(oAuth2IntrospectionResponseDTO.getBindingType(),
@@ -288,15 +297,51 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
     }
 
     /**
+     * Get the token id for a given access token.
+     *
+     * @param accessToken The access token value.
+     * @return The id of the token as a string.
+     */
+    private String getTokenIdFromAccessToken(String accessToken) {
+
+        String tokenId = null;
+        try {
+            AccessTokenDO accessTokenDO = OAuth2Util.findAccessToken(accessToken, false);
+            if (accessTokenDO != null) {
+                tokenId = accessTokenDO.getTokenId();
+            }
+        } catch (IdentityOAuth2Exception e) {
+            log.error("Error occurred while getting the access token id from the token", e);
+        }
+        return tokenId;
+    }
+
+    /**
      * Set token binding value which corresponds to the current session id to a thread local to be used down the flow.
      * @param tokenBindingValue     Token Binding value.
      */
     private void setCurrentSessionIdThreadLocal(String tokenBindingValue) {
 
         if (StringUtils.isNotBlank(tokenBindingValue)) {
-            IdentityUtil.threadLocalProperties.get().put(Constants.CURRENT_SESSION_IDENTIFIER, tokenBindingValue);
+            IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.CURRENT_SESSION_IDENTIFIER,
+                    tokenBindingValue);
             if (log.isDebugEnabled()) {
                 log.debug("Current session identifier: " + tokenBindingValue + " is added to thread local.");
+            }
+        }
+    }
+
+    /**
+     * Set the current access token id to a thread local to be used down the flow.
+     *
+     * @param accessTokenId The id of the token.
+     */
+    private void setCurrentTokenIdThreadLocal(String accessTokenId) {
+
+        if (StringUtils.isNotBlank(accessTokenId)) {
+            IdentityUtil.threadLocalProperties.get().put(FrameworkConstants.CURRENT_TOKEN_IDENTIFIER, accessTokenId);
+            if (log.isDebugEnabled()) {
+                log.debug("Current token identifier is added to thread local. Token id: " + accessTokenId);
             }
         }
     }

--- a/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java
+++ b/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java
@@ -27,6 +27,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.slf4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.auth.service.AuthenticationManager;
@@ -169,6 +170,8 @@ public class AuthenticationValve extends ValveBase {
             unsetCurrentSessionIdThreadLocal();
             // Clear thread local authenticated user tenant domain.
             unsetThreadLocalAuthUserTenantDomain();
+            // Clear thread local current access token id.
+            unsetCurrentTokenIdThreadLocal();
             // Clear thread local provisioning service provider.
             IdentityApplicationManagementUtil.resetThreadLocalProvisioningServiceProvider();
             // Clear Thread Locals from MDC.
@@ -280,6 +283,20 @@ public class AuthenticationValve extends ValveBase {
         }
         if (IdentityUtil.threadLocalProperties.get().get(Constants.IDP_NAME) != null) {
             IdentityUtil.threadLocalProperties.get().remove(Constants.IDP_NAME);
+        }
+    }
+
+    /**
+     * Remove current access token id from thread local, which is set in OAuth2AccessTokenHandler.
+     */
+    private void unsetCurrentTokenIdThreadLocal() {
+
+        if (IdentityUtil.threadLocalProperties.get().get(FrameworkConstants.CURRENT_TOKEN_IDENTIFIER) != null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing the current token identifier from thread local. Token id: "
+                        + IdentityUtil.threadLocalProperties.get().get(FrameworkConstants.CURRENT_TOKEN_IDENTIFIER));
+            }
+            IdentityUtil.threadLocalProperties.get().remove(FrameworkConstants.CURRENT_TOKEN_IDENTIFIER);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
         <org.wso2.carbon.identity.cors.valve.version>${project.version}</org.wso2.carbon.identity.cors.valve.version>
 
         <!--Carbon identity version-->
-        <identity.framework.version>5.20.112</identity.framework.version>
+        <identity.framework.version>5.21.63</identity.framework.version>
         <carbon.identity.package.import.version.range>[5.17.8, 6.0.0)</carbon.identity.package.import.version.range>
 
         <org.wso2.carbon.identity.oauth.version>6.4.149</org.wso2.carbon.identity.oauth.version>


### PR DESCRIPTION
### Proposed changes in this pull request
Set current access token id to the threadlocal to use in the password reset

Related to wso2/product-is#11786

Depends on: wso2/carbon-identity-framework#4189