### PR TITLE
Fix for null pointer exception when organization context rewrites not properly loaded

### DIFF
--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/OrganizationContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/OrganizationContextRewriteValve.java
@@ -63,9 +63,7 @@ public class OrganizationContextRewriteValve extends ValveBase {
     protected synchronized void startInternal() throws LifecycleException {
 
         super.startInternal();
-        if (ContextRewriteValveServiceComponentHolder.getInstance().isOrganizationManagementEnabled()) {
-            orgContextsToRewrite = getOrgContextsToRewrite();
-        }
+        orgContextsToRewrite = getOrgContextsToRewrite();
     }
 
     @Override


### PR DESCRIPTION
### Purpose
At the server startup the organization context rewrites were loaded if the organization management feature is enabled. The bundle which is used to check whether the feature is enabled can be not active status when the below code segment is executed and result in null value for the `orgContextRewrite` variable. 

![Screenshot 2022-08-12 at 15 43 21](https://user-images.githubusercontent.com/35717390/184343550-1ff07063-a879-4a3a-977b-b1e8a60d7215.png)

### Related Issues
- https://github.com/wso2-enterprise/identity-org-mgt-connector/issues/18


