### PR TITLE
Improve org-rewrite-context extraction  algoritham from identity configurations file

### DIFF
--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/OrganizationRewriteContext.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/OrganizationRewriteContext.java
@@ -28,7 +28,7 @@ public class OrganizationRewriteContext {
 
     private boolean isWebApp;
     private String context;
-    private List<String> subContexts = new ArrayList<>();
+    private List<String> subPaths = new ArrayList<>();
 
     public OrganizationRewriteContext(boolean isWebApp, String context) {
 
@@ -41,9 +41,9 @@ public class OrganizationRewriteContext {
         return context;
     }
 
-    public List<String> getSubContexts() {
+    public List<String> getSubPaths() {
 
-        return subContexts;
+        return subPaths;
     }
 
     public boolean isWebApp() {
@@ -51,8 +51,8 @@ public class OrganizationRewriteContext {
         return isWebApp;
     }
 
-    public void addSubContext(String subContext) {
+    public void addSubPath(String subPath) {
 
-        this.subContexts.add(subContext);
+        this.subPaths.add(subPath);
     }
 }

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/OrganizationRewriteContext.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/OrganizationRewriteContext.java
@@ -21,12 +21,13 @@ package org.wso2.carbon.identity.context.rewrite.bean;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * Bean for organization qualified context rewrites.
+ */
 public class OrganizationRewriteContext {
 
     private boolean isWebApp;
-
     private String context;
-
     private List<String> subContexts = new ArrayList<>();
 
     public OrganizationRewriteContext(boolean isWebApp, String context) {

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/OrganizationRewriteContext.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/OrganizationRewriteContext.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.context.rewrite.bean;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OrganizationRewriteContext {
+
+    private boolean isWebApp;
+
+    private String context;
+
+    private List<String> subContexts = new ArrayList<>();
+
+    public OrganizationRewriteContext(boolean isWebApp, String context) {
+
+        this.isWebApp = isWebApp;
+        this.context = context;
+    }
+
+    public String getContext() {
+
+        return context;
+    }
+
+    public List<String> getSubContexts() {
+
+        return subContexts;
+    }
+
+    public boolean isWebApp() {
+
+        return isWebApp;
+    }
+
+    public void addSubContext(String subContext) {
+
+        this.subContexts.add(subContext);
+    }
+}

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/OrganizationContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/OrganizationContextRewriteValve.java
@@ -176,7 +176,7 @@ public class OrganizationContextRewriteValve extends ValveBase {
                     organizationRewriteContexts.add(new OrganizationRewriteContext(isWebApp, context));
                 }
             } else {
-                organizationRewriteContexts.add(new OrganizationRewriteContext(true,
+                organizationRewriteContexts.add(new OrganizationRewriteContext(isWebApp,
                         basePathContexts.toString()));
             }
         }

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/OrganizationContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/OrganizationContextRewriteValve.java
@@ -124,8 +124,13 @@ public class OrganizationContextRewriteValve extends ValveBase {
 
             String orgDomain = getOrganizationDomainFromURL(requestURI);
 
-            String dispatchLocation = "/" +
-                    requestURI.replace(ORGANIZATION_PATH_PARAM + orgDomain + contextToForward, StringUtils.EMPTY);
+            String dispatchLocation;
+            if (StringUtils.contains(requestURI, ORGANIZATION_PATH_PARAM + orgDomain + contextToForward)) {
+                dispatchLocation = "/" + requestURI.replace(ORGANIZATION_PATH_PARAM + orgDomain +
+                        contextToForward, StringUtils.EMPTY);
+            } else {
+                dispatchLocation = requestURI.replace(ORGANIZATION_PATH_PARAM + orgDomain, StringUtils.EMPTY);
+            }
             request.getContext().setCrossContext(true);
             request.getServletContext().getContext(contextToForward)
                     .getRequestDispatcher(dispatchLocation).forward(request, response);

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/OrganizationContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/OrganizationContextRewriteValve.java
@@ -85,9 +85,9 @@ public class OrganizationContextRewriteValve extends ValveBase {
                     isWebApp = organizationRewriteContext.isWebApp();
                     contextToForward = organizationRewriteContext.getContext();
 
-                    if (CollectionUtils.isNotEmpty(organizationRewriteContext.getSubContexts())) {
+                    if (CollectionUtils.isNotEmpty(organizationRewriteContext.getSubPaths())) {
                         subPathsConfigured = true;
-                        for (String subPath : organizationRewriteContext.getSubContexts()) {
+                        for (String subPath : organizationRewriteContext.getSubPaths()) {
                             if (StringUtils.contains(requestURI, subPath)) {
                                 orgRoutingSubPathSupported = true;
                                 break;
@@ -187,12 +187,12 @@ public class OrganizationContextRewriteValve extends ValveBase {
 
         if (subPathContexts != null) {
             if (subPathContexts instanceof ArrayList) {
-                for (String subContext : (ArrayList<String>) subPathContexts) {
+                for (String subPath : (ArrayList<String>) subPathContexts) {
                     Optional<OrganizationRewriteContext> maybeOrgRewriteContext = organizationRewriteContexts.stream()
-                            .filter(rewriteContext -> subContext.startsWith(rewriteContext.getContext()))
+                            .filter(rewriteContext -> subPath.startsWith(rewriteContext.getContext()))
                             .findFirst();
                     maybeOrgRewriteContext.ifPresent(
-                            organizationRewriteContext -> organizationRewriteContext.addSubContext(subContext));
+                            organizationRewriteContext -> organizationRewriteContext.addSubPath(subPath));
                 }
             }
         }


### PR DESCRIPTION
### Proposed changes in this pull request

The organization context rewrite configuration extraction logic is further improved as follows. `orgContextsToRewrite` is a list of `OrganizationRewriteContext` objects which holds the necessary information like whether webapps/servlet related config and the supported sub paths as shown in below figure.

<img width="909" alt="Screenshot 2022-08-26 at 18 59 39" src="https://user-images.githubusercontent.com/35717390/186917240-b0f8336c-6eba-4042-9dda-3e0e15ee5149.png">

Also, the organization rewrite contexts evaluating logic also improved based on the new configuration model.

### Related issues

The below issue is fixed by the introduced rewrite context configuration evaluation logic.

- https://github.com/wso2-enterprise/identity-org-mgt-connector/issues/17