### PR TITLE
Remove blocking behaviour from the CORS valve

### DIFF
--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/CORSValve.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/CORSValve.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/CORSValve.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/CORSValve.java
@@ -1,20 +1,19 @@
-/*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- * NOTE: The code/logic in this class is copied from https://bitbucket.org/thetransactioncompany/cors-filter.
- * All credits goes to the original authors of the project https://bitbucket.org/thetransactioncompany/cors-filter.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.cors.valve;
@@ -77,7 +76,7 @@ public class CORSValve extends ValveBase {
                 corsRequestHandler.handleSimpleRequest(request, response);
                 getNext().invoke(request, response);
             } else if (corsRequestType == CORSRequestType.PREFLIGHT) {
-                // Preflight requests.
+                // Preflight requests - Handle but don't pass further down the chain.
                 corsRequestHandler.handlePreflightRequest(request, response);
             } else {
                 // Not CORS requests.

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/CORSValve.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/CORSValve.java
@@ -73,7 +73,7 @@ public class CORSValve extends ValveBase {
 
             if (corsRequestType == CORSRequestType.SIMPLE || corsRequestType == CORSRequestType.ACTUAL) {
                 // Simple and Actual requests are handled in a same way.
-                corsRequestHandler.handleSimpleRequest(request, response);
+                corsRequestHandler.handleActualRequest(request, response);
                 getNext().invoke(request, response);
             } else if (corsRequestType == CORSRequestType.PREFLIGHT) {
                 // Preflight requests - Handle but don't pass further down the chain.

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/constant/RequestMethod.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/constant/RequestMethod.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/constant/RequestMethod.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/constant/RequestMethod.java
@@ -1,17 +1,17 @@
-/*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/constant/RequestMethod.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/constant/RequestMethod.java
@@ -23,24 +23,12 @@ package org.wso2.carbon.identity.cors.valve.constant;
  */
 public class RequestMethod {
 
-    /**
-     * "GET" method.
-     */
     public static final String GET = "GET";
 
-    /**
-     * "HEAD" method.
-     */
     public static final String HEAD = "HEAD";
 
-    /**
-     * "POST" method.
-     */
     public static final String POST = "POST";
 
-    /**
-     * "OPTIONS" method.
-     */
     public static final String OPTIONS = "OPTIONS";
 
     /**

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/constant/RequestMethod.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/constant/RequestMethod.java
@@ -24,6 +24,21 @@ package org.wso2.carbon.identity.cors.valve.constant;
 public class RequestMethod {
 
     /**
+     * "GET" method.
+     */
+    public static final String GET = "GET";
+
+    /**
+     * "HEAD" method.
+     */
+    public static final String HEAD = "HEAD";
+
+    /**
+     * "POST" method.
+     */
+    public static final String POST = "POST";
+
+    /**
      * "OPTIONS" method.
      */
     public static final String OPTIONS = "OPTIONS";

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/handler/CORSRequestHandler.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/handler/CORSRequestHandler.java
@@ -55,12 +55,11 @@ public class CORSRequestHandler {
      * @throws CORSException
      * @throws CORSManagementServiceException
      */
-    public void handleSimpleRequest(HttpServletRequest request, HttpServletResponse response)
+    public void handleActualRequest(HttpServletRequest request, HttpServletResponse response)
             throws CORSException, CORSManagementServiceException {
 
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         CORSConfiguration config = getCORSManager().getCORSConfiguration(tenantDomain);
-
         addStandardHeaders(request, response, config);
     }
 

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/handler/CORSRequestHandler.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/handler/CORSRequestHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -83,9 +83,6 @@ public class CORSRequestHandler {
             // of the Origin header as value.
             if (isAllowedOrigin(tenantDomain, requestOrigin)) {
                 response.addHeader(Header.ACCESS_CONTROL_ALLOW_ORIGIN, requestOrigin.toString());
-            } else {
-                response.addHeader(Header.ACCESS_CONTROL_ALLOW_ORIGIN, "null");
-                return;
             }
         }
 

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/handler/CORSRequestHandler.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/handler/CORSRequestHandler.java
@@ -1,22 +1,19 @@
-/*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
- * NOTE: The code/logic in this class is copied from https://bitbucket.org/thetransactioncompany/cors-filter.
- * All credits goes to the original authors of the project https://bitbucket.org/thetransactioncompany/cors-filter.
  */
 
 package org.wso2.carbon.identity.cors.valve.internal.handler;

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/CORSUtils.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/CORSUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/CORSUtils.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/CORSUtils.java
@@ -1,22 +1,19 @@
-/*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
- * NOTE: The code/logic in this class is copied from https://bitbucket.org/thetransactioncompany/cors-filter.
- * All credits goes to the original authors of the project https://bitbucket.org/thetransactioncompany/cors-filter.
  */
 
 package org.wso2.carbon.identity.cors.valve.internal.util;

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/CORSUtils.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/CORSUtils.java
@@ -64,7 +64,7 @@ public class CORSUtils {
                 (request.getHeader(Header.HOST) != null && request.getHeader(Header.ORIGIN).equals(serverOrigin))) {
             // Condition I   - A request without the Origin header is never a CORS nor Preflight request.
             // Condition II  - Requests that have Origin header but submitted for the same domain.
-            return CORSRequestType.NON_CORS;
+            return CORSRequestType.NOT_CORS;
         } else if (GET.equals(method) || HEAD.equals(method) ||
                 (POST.equals(method) && SIMPLE_HTTP_REQUEST_CONTENT_TYPE_VALUES.contains(mediaType))) {
             return CORSRequestType.SIMPLE;

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/CORSUtils.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/CORSUtils.java
@@ -22,7 +22,7 @@
 package org.wso2.carbon.identity.cors.valve.internal.util;
 
 import org.wso2.carbon.identity.cors.valve.constant.Header;
-import org.wso2.carbon.identity.cors.valve.constant.RequestMethod;
+
 import org.wso2.carbon.identity.cors.valve.model.CORSRequestType;
 
 import javax.servlet.http.HttpServletRequest;
@@ -30,6 +30,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+
+import static org.wso2.carbon.identity.cors.valve.constant.RequestMethod.GET;
+import static org.wso2.carbon.identity.cors.valve.constant.RequestMethod.HEAD;
+import static org.wso2.carbon.identity.cors.valve.constant.RequestMethod.OPTIONS;
+import static org.wso2.carbon.identity.cors.valve.constant.RequestMethod.POST;
 
 /**
  * A utility class for CORS operations.
@@ -59,15 +64,15 @@ public class CORSUtils {
         String method = request.getMethod();
         String mediaType = HeaderUtils.getMediaType(request.getContentType());
         if (request.getHeader(Header.ORIGIN) == null ||
-                (request.getHeader(Header.HOST) != null && request.getHeader(Header.ORIGIN).equals(serverOrigin)) ||
-                ("POST".equals(method) && SIMPLE_HTTP_REQUEST_CONTENT_TYPE_VALUES.contains(mediaType))) {
+                (request.getHeader(Header.HOST) != null && request.getHeader(Header.ORIGIN).equals(serverOrigin))) {
             // Condition I   - A request without the Origin header is never a CORS nor Preflight request.
             // Condition II  - Requests that have Origin header but submitted for the same domain.
-            // Condition III - A request with a simple HTTP Post Request content type value.
-            return CORSRequestType.OTHER;
+            return CORSRequestType.NON_CORS;
+        } else if (GET.equals(method) || HEAD.equals(method) ||
+                (POST.equals(method) && SIMPLE_HTTP_REQUEST_CONTENT_TYPE_VALUES.contains(mediaType))) {
+            return CORSRequestType.SIMPLE;
         } else if (request.getHeader(Header.ACCESS_CONTROL_REQUEST_METHOD) != null &&
-                request.getMethod() != null &&
-                request.getMethod().equalsIgnoreCase(RequestMethod.OPTIONS)) {
+                OPTIONS.equals(method)) {
             return CORSRequestType.PREFLIGHT;
         } else {
             return CORSRequestType.ACTUAL;

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/RequestTagger.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/RequestTagger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/RequestTagger.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/RequestTagger.java
@@ -1,22 +1,19 @@
-/*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
- * NOTE: The code/logic in this class is copied from https://bitbucket.org/thetransactioncompany/cors-filter.
- * All credits goes to the original authors of the project https://bitbucket.org/thetransactioncompany/cors-filter.
  */
 
 package org.wso2.carbon.identity.cors.valve.internal.util;

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/RequestTagger.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/RequestTagger.java
@@ -64,7 +64,7 @@ public final class RequestTagger {
                 request.setAttribute("cors.requestType", "preflight");
                 request.setAttribute("cors.requestHeaders", request.getHeader(Header.ACCESS_CONTROL_REQUEST_HEADERS));
                 break;
-            case OTHER:
+            case NON_CORS:
                 request.setAttribute("cors.isCorsRequest", false);
         }
     }

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/RequestTagger.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/internal/util/RequestTagger.java
@@ -61,7 +61,7 @@ public final class RequestTagger {
                 request.setAttribute("cors.requestType", "preflight");
                 request.setAttribute("cors.requestHeaders", request.getHeader(Header.ACCESS_CONTROL_REQUEST_HEADERS));
                 break;
-            case NON_CORS:
+            case NOT_CORS:
                 request.setAttribute("cors.isCorsRequest", false);
         }
     }

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/model/CORSRequestType.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/model/CORSRequestType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+ * Copyright (c) 2020, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/model/CORSRequestType.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/model/CORSRequestType.java
@@ -1,22 +1,19 @@
-/*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+/**
+ * Copyright (c) 2022, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
- * NOTE: The code/logic in this class is copied from https://bitbucket.org/thetransactioncompany/cors-filter.
- * All credits goes to the original authors of the project https://bitbucket.org/thetransactioncompany/cors-filter.
  */
 
 package org.wso2.carbon.identity.cors.valve.model;

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/model/CORSRequestType.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/model/CORSRequestType.java
@@ -25,5 +25,5 @@ public enum CORSRequestType {
     ACTUAL,
     PREFLIGHT,
     SIMPLE,
-    NON_CORS
+    NOT_CORS
 }

--- a/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/model/CORSRequestType.java
+++ b/components/org.wso2.carbon.identity.cors.valve/src/main/java/org/wso2/carbon/identity/cors/valve/model/CORSRequestType.java
@@ -27,5 +27,6 @@ package org.wso2.carbon.identity.cors.valve.model;
 public enum CORSRequestType {
     ACTUAL,
     PREFLIGHT,
-    OTHER
+    SIMPLE,
+    NON_CORS
 }


### PR DESCRIPTION
### Proposed changes in this pull request
Remove blocking behaviour from the CORS valve. After this fix, the cors valve will only add the relevant headers to the response, and the blocking will be happened only in the browser level.

Request types:
- **SIMPLE**: Check the origin, set `Access-Control-Allow-Origin` and `Vary` headers and continue
- **ACTUAL**: Handles similar to the SIMPLE requests.
- **PREFLIGHT**: Set `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Headers` and `Access-Control-Max-Age` header and return.
- **NOCORS**: Not setting any cors related headers and continue

**Related Issue:** wso2/product-is#14490


