### PR TITLE
Enable realm user field based WWW-Authenticate from config

### DIFF
--- a/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/util/APIErrorResponseHandler.java
+++ b/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/util/APIErrorResponseHandler.java
@@ -22,7 +22,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -44,6 +46,10 @@ public class APIErrorResponseHandler {
     private static final String FORBIDDEN_ERROR_MSG = "Operation is not permitted. You do not have permissions to " +
             "make this request.";
 
+    private static final String ADD_REALM_USER_CONFIG = "WWWAuthenticate.AddRealmUser";
+
+    private static final boolean addRealmUser = parseAddRealmUser();
+
     /**
      * Generate the error response according to the relevant API endpoint and the HTTP status.
      */
@@ -53,13 +59,18 @@ public class APIErrorResponseHandler {
         if (log.isDebugEnabled() && e != null) {
             log.debug("Authentication Error ", e);
         }
-        StringBuilder value = new StringBuilder(16);
-        value.append("realm user=\"");
-        if (authenticationContext != null && authenticationContext.getUser() != null) {
-            value.append(authenticationContext.getUser().getUserName());
+        if (error == HttpServletResponse.SC_UNAUTHORIZED) {
+            response.setHeader(AUTH_HEADER_NAME, getRealmInfo());
         }
-        value.append('\"');
-        response.setHeader(AUTH_HEADER_NAME, value.toString());
+        else if (addRealmUser){
+            StringBuilder value = new StringBuilder(16);
+            value.append("realm user=\"");
+            if (authenticationContext != null && authenticationContext.getUser() != null) {
+                value.append(authenticationContext.getUser().getUserName());
+            }
+            value.append('\"');
+            response.setHeader(AUTH_HEADER_NAME, value.toString());
+        }
         if (response.getRequest() != null) {
             String uri = response.getRequest().getRequestURI();
             uri = removeTenantDetailFromURI(uri);
@@ -201,5 +212,19 @@ public class APIErrorResponseHandler {
     private static boolean isCorrelationIDPresent() {
 
         return MDC.get(CORRELATION_ID_MDC) != null;
+    }
+
+    private static String getRealmInfo() {
+
+        return "Basic realm=" + ServerConfiguration.getInstance().getFirstProperty("HostName");
+    }
+
+    private static boolean parseAddRealmUser() {
+
+        String addRealmUSer = IdentityUtil.getProperty(ADD_REALM_USER_CONFIG);
+        if (StringUtils.isNotBlank(addRealmUSer)) {
+            return Boolean.parseBoolean(addRealmUSer);
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Proposed changes in this pull request

- 401 errors for REST API authentication will have a `WWW-Authenticate` header with Challenge and `realm` fields
- Other errors will have a `WWW-Authenticate` header with custom `realm user` field only when the following config enables this.
```
[www_authenticate]
add_realm_user = true
```

### When should this PR be merged

This should be merged after https://github.com/wso2/carbon-identity-framework/pull/4285