### PR TITLE
Update authorization manager selection for o/ path accessed API

### DIFF
--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -75,7 +75,9 @@ public class AuthorizationValve extends ValveBase {
             String requestURI = request.getRequestURI();
             String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
             if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenantDomain) &&
-                    requestURI.startsWith(ORGANIZATION_PATH_PARAM)) {
+                    requestURI.startsWith(ORGANIZATION_PATH_PARAM) &&
+                    org.wso2.carbon.identity.organization.management.service.util.Utils.useOrganizationRolesForValidation(
+                            PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId())) {
                 /*
                 If the request is authenticated using an oauth2 access token and scope validation is required,
                 the token obtained tenant domain should be equal to the accessed resource's tenant domain.

--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
         </org.wso2.carbon.identity.organization.management.version>
         <org.wso2.carbon.identity.organization.management.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.version.range>
-        <org.wso2.carbon.identity.organization.management.core.version>1.0.0
+        <org.wso2.carbon.identity.organization.management.core.version>1.0.13
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request
If the first-level organizations are managed using carbon roles, even if the resources get accessed via `o/<org id>`, the authorization should be happened through  carbon roles