### PR TITLE
Fix generic authentication prompt getting displayed

### DIFF
--- a/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/util/APIErrorResponseHandler.java
+++ b/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/util/APIErrorResponseHandler.java
@@ -216,7 +216,7 @@ public class APIErrorResponseHandler {
 
     private static String getRealmInfo() {
 
-        return "Basic realm=" + ServerConfiguration.getInstance().getFirstProperty("HostName");
+        return "Bearer realm=" + ServerConfiguration.getInstance().getFirstProperty("HostName");
     }
 
     private static boolean parseAddRealmUser() {


### PR DESCRIPTION
### Proposed changes in this pull request
Change the Challenge type from Basic to Bearer to prevent a generic authentication prompt popup for 401 Responses of APIs.

