### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -323,20 +323,20 @@
     <properties>
         <org.wso2.carbon.identity.auth.service.version>${project.version}
         </org.wso2.carbon.identity.auth.service.version>
-        <org.wso2.carbon.identity.auth.service.version.range>[1.3.0, 2.0.0)
+        <org.wso2.carbon.identity.auth.service.version.range>[2.0.0, 3.0.0)
         </org.wso2.carbon.identity.auth.service.version.range>
 
         <org.wso2.carbon.identity.auth.valve.version>${project.version}</org.wso2.carbon.identity.auth.valve.version>
-        <org.wso2.carbon.identity.auth.valve.version.range>[1.3.0, 2.0.0)
+        <org.wso2.carbon.identity.auth.valve.version.range>[2.0.0, 3.0.0)
         </org.wso2.carbon.identity.auth.valve.version.range>
 
         <org.wso2.carbon.identity.authz.service.version>${project.version}
         </org.wso2.carbon.identity.authz.service.version>
-        <org.wso2.carbon.identity.authz.service.version.range>[1.3.0, 2.0.0)
+        <org.wso2.carbon.identity.authz.service.version.range>[2.0.0, 3.0.0)
         </org.wso2.carbon.identity.authz.service.version.range>
 
         <org.wso2.carbon.identity.authz.valve.version>${project.version}</org.wso2.carbon.identity.authz.valve.version>
-        <org.wso2.carbon.identity.authz.valve.version.range>[1.3.0, 2.0.0)
+        <org.wso2.carbon.identity.authz.valve.version.range>[2.0.0, 3.0.0)
         </org.wso2.carbon.identity.authz.valve.version.range>
 
         <org.wso2.carbon.identity.context.rewrite.valve.version>${project.version}</org.wso2.carbon.identity.context.rewrite.valve.version>
@@ -345,20 +345,20 @@
         <org.wso2.carbon.identity.cors.valve.version>${project.version}</org.wso2.carbon.identity.cors.valve.version>
 
         <!--Carbon identity version-->
-        <identity.framework.version>5.23.34</identity.framework.version>
-        <carbon.identity.package.import.version.range>[5.17.8, 6.0.0)</carbon.identity.package.import.version.range>
+        <identity.framework.version>6.0.0</identity.framework.version>
+        <carbon.identity.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.package.import.version.range>
 
-        <org.wso2.carbon.identity.oauth.version>6.4.149</org.wso2.carbon.identity.oauth.version>
-        <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 7.0.0)
+        <org.wso2.carbon.identity.oauth.version>7.0.0</org.wso2.carbon.identity.oauth.version>
+        <org.wso2.carbon.identity.oauth.import.version.range>[7.0.0, 8.0.0)
         </org.wso2.carbon.identity.oauth.import.version.range>
 
-        <org.wso2.carbon.identity.organization.management.version>1.1.14
+        <org.wso2.carbon.identity.organization.management.version>2.0.0
         </org.wso2.carbon.identity.organization.management.version>
-        <org.wso2.carbon.identity.organization.management.version.range>[1.0.0, 2.0.0)
+        <org.wso2.carbon.identity.organization.management.version.range>[2.0.0, 3.0.0)
         </org.wso2.carbon.identity.organization.management.version.range>
-        <org.wso2.carbon.identity.organization.management.core.version>1.0.17
+        <org.wso2.carbon.identity.organization.management.core.version>2.0.0
         </org.wso2.carbon.identity.organization.management.core.version>
-        <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
+        <org.wso2.carbon.identity.organization.management.core.version.range>[2.0.0, 3.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>
 
         <!-- OSGi framework component version -->


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16