### PR TITLE
Pattern match for sub organization context paths related sub paths

### DIFF
--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/OrganizationRewriteContext.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/OrganizationRewriteContext.java
@@ -32,7 +32,7 @@ public class OrganizationRewriteContext {
     private boolean isWebApp;
     private String context;
     private Pattern orgContextPattern;
-    private List<String> subPaths = new ArrayList<>();
+    private List<Pattern> subPaths = new ArrayList<>();
 
     public OrganizationRewriteContext(boolean isWebApp, String context) {
 
@@ -51,7 +51,7 @@ public class OrganizationRewriteContext {
         return orgContextPattern;
     }
 
-    public List<String> getSubPaths() {
+    public List<Pattern> getSubPaths() {
 
         return subPaths;
     }
@@ -61,7 +61,7 @@ public class OrganizationRewriteContext {
         return isWebApp;
     }
 
-    public void addSubPath(String subPath) {
+    public void addSubPath(Pattern subPath) {
 
         this.subPaths.add(subPath);
     }

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/OrganizationContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/OrganizationContextRewriteValve.java
@@ -87,8 +87,8 @@ public class OrganizationContextRewriteValve extends ValveBase {
 
                     if (CollectionUtils.isNotEmpty(organizationRewriteContext.getSubPaths())) {
                         subPathsConfigured = true;
-                        for (String subPath : organizationRewriteContext.getSubPaths()) {
-                            if (StringUtils.contains(requestURI, subPath)) {
+                        for (Pattern subPath : organizationRewriteContext.getSubPaths()) {
+                            if (subPath.matcher(requestURI).find() || subPath.matcher(requestURI + "/").find()) {
                                 orgRoutingSubPathSupported = true;
                                 break;
                             }
@@ -192,7 +192,8 @@ public class OrganizationContextRewriteValve extends ValveBase {
                             .filter(rewriteContext -> subPath.startsWith(rewriteContext.getContext()))
                             .max(Comparator.comparingInt(rewriteContext -> rewriteContext.getContext().length()));
                     maybeOrgRewriteContext.ifPresent(
-                            organizationRewriteContext -> organizationRewriteContext.addSubPath(subPath));
+                            organizationRewriteContext -> organizationRewriteContext.addSubPath(
+                                    Pattern.compile("^" + ORGANIZATION_PATH_PARAM + "([^/]+)" + subPath)));
                 }
             }
         }


### PR DESCRIPTION
### Proposed changes in this pull request

Improve the sub organization context related sub paths checking mechanism to match patterns, in order to give the flexibility to have the API paths as shown in below figure.


![Untitled Diagram-Page-11 (1)](https://user-images.githubusercontent.com/35717390/217450613-169ddb1f-5a92-4f64-9d35-e095fb2481e0.jpg)

