### PR TITLE
Resolved the user when user ID is set as the user name

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
@@ -128,14 +128,15 @@ public abstract class AuthenticationHandler extends AbstractIdentityMessageHandl
                     String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
                     if (StringUtils.isNotBlank(organizationId)) {
                         try {
-                            OrganizationUserResidentResolverService orgUserResolver = AuthenticationServiceHolder
+                            OrganizationUserResidentResolverService orgUserResolverService = AuthenticationServiceHolder
                                     .getInstance().getOrganizationUserResidentResolverService();
-                            Optional<org.wso2.carbon.user.core.common.User> resolvedUser = orgUserResolver
+                            Optional<org.wso2.carbon.user.core.common.User> resolvedUser = orgUserResolverService
                                     .resolveUserFromResidentOrganization(
                                             user.getUserName(), null, organizationId);
 
+                            // Handle scenarios where the user id is set as the username.
                             if (!resolvedUser.isPresent()) {
-                                resolvedUser = orgUserResolver.resolveUserFromResidentOrganization(
+                                resolvedUser = orgUserResolverService.resolveUserFromResidentOrganization(
                                         null, user.getUserName(), organizationId);
                             }
 

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.auth.service.internal.AuthenticationServiceHolde
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
 import java.util.Optional;
@@ -127,9 +128,17 @@ public abstract class AuthenticationHandler extends AbstractIdentityMessageHandl
                     String organizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
                     if (StringUtils.isNotBlank(organizationId)) {
                         try {
-                            Optional<org.wso2.carbon.user.core.common.User> resolvedUser = AuthenticationServiceHolder
-                                    .getInstance().getOrganizationUserResidentResolverService()
-                                    .resolveUserFromResidentOrganization(user.getUserName(), null, organizationId);
+                            OrganizationUserResidentResolverService orgUserResolver = AuthenticationServiceHolder
+                                    .getInstance().getOrganizationUserResidentResolverService();
+                            Optional<org.wso2.carbon.user.core.common.User> resolvedUser = orgUserResolver
+                                    .resolveUserFromResidentOrganization(
+                                            user.getUserName(), null, organizationId);
+
+                            if (!resolvedUser.isPresent()) {
+                                resolvedUser = orgUserResolver.resolveUserFromResidentOrganization(
+                                        null, user.getUserName(), organizationId);
+                            }
+
                             if (resolvedUser.isPresent()) {
                                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserId(resolvedUser.get()
                                         .getUserID());


### PR DESCRIPTION
### Proposed changes in this pull request

In certain scenarios for organisation specific calls, the userId is set as the username value of authorized user. This PR adds changes to handle such scenarios.