### PR TITLE
Authorization valve and tenant context valve improvements for support B2B use cases

### DIFF
--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2023, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -26,6 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.auth.service.exception.AuthRuntimeException;
 import org.wso2.carbon.identity.auth.service.handler.HandlerManager;
@@ -41,6 +42,7 @@ import org.wso2.carbon.identity.authz.service.exception.AuthzServiceServerExcept
 import org.wso2.carbon.identity.authz.valve.internal.AuthorizationValveServiceHolder;
 import org.wso2.carbon.identity.authz.valve.util.Utils;
 import org.wso2.carbon.identity.organization.management.authz.service.OrganizationManagementAuthorizationContext;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
 import java.io.IOException;
@@ -91,7 +93,7 @@ public class AuthorizationValve extends ValveBase {
                  */
                 Object scopeValidationEnabled = authenticationContext.getParameter(OAUTH2_VALIDATE_SCOPE);
                 if (scopeValidationEnabled != null && Boolean.parseBoolean(scopeValidationEnabled.toString())) {
-                    if (!Utils.isUserBelongsToRequestedTenant(authenticationContext, request)) {
+                    if (!Utils.isUserAuthorizedOrganization(authenticationContext, request)) {
                         if (log.isDebugEnabled()) {
                             log.debug("Authorization to " + request.getRequestURI() +
                                     " is denied because the used access token issued from a different tenant domain: " +
@@ -158,7 +160,19 @@ public class AuthorizationValve extends ValveBase {
                 try {
                     AuthorizationResult authorizationResult = authorizationManager.authorize(authorizationContext);
                     if (authorizationResult.getAuthorizationStatus().equals(AuthorizationStatus.GRANT)) {
-                        getNext().invoke(request, response);
+                        String authorizedOrganization = ((AuthenticatedUser)authorizationContext.getUser())
+                                .getAccessingOrganization();
+                        // Start tenant flow corresponds to the accessed organization.
+                        if (StringUtils.isNotEmpty(authorizedOrganization)) {
+                            try {
+                                startOrganizationBoundTenantFlow(authorizedOrganization);
+                                getNext().invoke(request, response);
+                            } finally {
+                                PrivilegedCarbonContext.endTenantFlow();
+                            }
+                        } else {
+                            getNext().invoke(request, response);
+                        }
                     } else {
                         APIErrorResponseHandler.handleErrorResponse(authenticationContext, response,
                                 HttpServletResponse.SC_FORBIDDEN, null);
@@ -280,6 +294,19 @@ public class AuthorizationValve extends ValveBase {
                     endpoint -> Pattern.compile(endpoint).matcher(normalizedRequestURI).matches());
         } catch (URISyntaxException | UnsupportedEncodingException e) {
             throw new AuthRuntimeException("Error normalizing URL path: " + requestUri, e);
+        }
+    }
+
+    private void startOrganizationBoundTenantFlow(String authorizedOrganization) {
+
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setOrganizationId(authorizedOrganization);
+        try {
+            String authorizedTenantDomain = AuthorizationValveServiceHolder.getInstance().getOrganizationManager()
+                    .resolveTenantDomain(authorizedOrganization);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(authorizedTenantDomain, true);
+        } catch (OrganizationManagementException e) {
+            throw new AuthRuntimeException("Error while resolving tenant domain by organization.", e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -83,6 +83,7 @@ public class AuthorizationValve extends ValveBase {
 
             String requestURI = request.getRequestURI();
             String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            // The below check on organization qualified resource access should be removed.
             if (!StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenantDomain) &&
                     requestURI.startsWith(ORGANIZATION_PATH_PARAM) &&
                     org.wso2.carbon.identity.organization.management.service.util.Utils.useOrganizationRolesForValidation(
@@ -93,7 +94,7 @@ public class AuthorizationValve extends ValveBase {
                  */
                 Object scopeValidationEnabled = authenticationContext.getParameter(OAUTH2_VALIDATE_SCOPE);
                 if (scopeValidationEnabled != null && Boolean.parseBoolean(scopeValidationEnabled.toString())) {
-                    if (!Utils.isUserAuthorizedOrganization(authenticationContext, request)) {
+                    if (!Utils.isUserAuthorizedForOrganization(authenticationContext, request)) {
                         if (log.isDebugEnabled()) {
                             log.debug("Authorization to " + request.getRequestURI() +
                                     " is denied because the used access token issued from a different tenant domain: " +

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/internal/AuthorizationValveServiceComponent.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/internal/AuthorizationValveServiceComponent.java
@@ -30,6 +30,7 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
 @Component(
          name = "org.wso2.carbon.identity.authz.valve", 
@@ -62,6 +63,25 @@ public class AuthorizationValveServiceComponent {
     protected void unsetAuthorizationManager(AuthorizationManager authorizationManager) {
         List<AuthorizationManager> authorizationManagerList = AuthorizationValveServiceHolder.getInstance().getAuthorizationManagerList();
         authorizationManagerList.remove(authorizationManager);
+    }
+
+    @Reference(
+            name = "organization.service",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager"
+    )
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        log.debug("Setting the organization management service.");
+        AuthorizationValveServiceHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        log.debug("Unset organization management service.");
+        AuthorizationValveServiceHolder.getInstance().setOrganizationManager(null);
     }
 }
 

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/internal/AuthorizationValveServiceHolder.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/internal/AuthorizationValveServiceHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.authz.valve.internal;
 
 import org.wso2.carbon.identity.authz.service.AuthorizationManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +31,7 @@ public class AuthorizationValveServiceHolder {
 
     private static AuthorizationValveServiceHolder authorizationValveServiceHolder = new
             AuthorizationValveServiceHolder();
+    private OrganizationManager organizationManager;
 
     private List<AuthorizationManager> authorizationManagerList = new ArrayList<>();
 
@@ -46,5 +48,16 @@ public class AuthorizationValveServiceHolder {
 
     public void setAuthorizationManagerList(List<AuthorizationManager> authorizationManagerList) {
         this.authorizationManagerList = authorizationManagerList;
+    }
+
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    public void setOrganizationManager(
+            OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
     }
 }

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
@@ -91,7 +91,7 @@ public class Utils {
         return tenantDomainFromURLMapping.equals(tenantDomain);
     }
 
-    public static boolean isUserAuthorizedOrganization(AuthenticationContext authenticationContext, Request request) {
+    public static boolean isUserAuthorizedForOrganization(AuthenticationContext authenticationContext, Request request) {
 
         User user = authenticationContext.getUser();
         if (user == null) {

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
@@ -19,7 +19,9 @@
 package org.wso2.carbon.identity.authz.valve.util;
 
 import org.apache.catalina.connector.Request;
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.auth.service.util.Constants;
@@ -50,6 +52,22 @@ public class Utils {
         return domain;
     }
 
+    public static String getOrganizationIdFromURLMapping(Request request) {
+
+        String requestURI = request.getRequestURI();
+        String organizationId = StringUtils.EMPTY;
+
+        if (requestURI.contains("/o/")) {
+            String temp = requestURI.substring(requestURI.indexOf("/o/") + 3);
+            int index = temp.indexOf('/');
+            if (index != -1) {
+                temp = temp.substring(0, index);
+                organizationId = temp;
+            }
+        }
+        return organizationId;
+    }
+
     /**
      * Checks whether the tenantDomain from URL mapping and the tenantDomain get from the user name are same.
      *
@@ -71,6 +89,19 @@ public class Utils {
             tenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
         }
         return tenantDomainFromURLMapping.equals(tenantDomain);
+    }
+
+    public static boolean isUserAuthorizedOrganization(AuthenticationContext authenticationContext, Request request) {
+
+        User user = authenticationContext.getUser();
+        if (user == null) {
+            return false;
+        }
+        String authorizedOrganization = ((AuthenticatedUser) user).getAccessingOrganization();
+        if (StringUtils.isNotEmpty(authorizedOrganization)) {
+            return getOrganizationIdFromURLMapping(request).equals(authorizedOrganization);
+        }
+        return isUserBelongsToRequestedTenant(authenticationContext, request);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
@@ -28,7 +28,6 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.slf4j.MDC;
-import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
@@ -92,6 +91,7 @@ public class TenantContextRewriteValve extends ValveBase {
         boolean isContextRewrite = false;
         boolean isWebApp = false;
 
+        String contextTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         //Get the rewrite contexts and check whether request URI contains any of rewrite contains.
         for (RewriteContext context : contextsToRewrite) {
             Pattern patternTenant = context.getTenantContextPattern();
@@ -103,8 +103,7 @@ public class TenantContextRewriteValve extends ValveBase {
                 break;
             } else if (isTenantQualifiedUrlsEnabled && (patternSuperTenant.matcher(requestURI).find() ||
                     patternSuperTenant.matcher(requestURI + "/").find())) {
-                IdentityUtil.threadLocalProperties.get().put(TENANT_NAME_FROM_CONTEXT, MultitenantConstants
-                        .SUPER_TENANT_DOMAIN_NAME);
+                IdentityUtil.threadLocalProperties.get().put(TENANT_NAME_FROM_CONTEXT, contextTenantDomain);
                 break;
             }
         }
@@ -143,7 +142,7 @@ public class TenantContextRewriteValve extends ValveBase {
                 IdentityUtil.threadLocalProperties.get().put(TENANT_NAME_FROM_CONTEXT, tenantDomain);
 
                 if (isWebApp) {
-                    String dispatchLocation = "/" + requestURI.replace("/t/" + tenantDomain + contextToForward, "");
+                    String dispatchLocation = "/" + requestURI.replaceAll("/t/.*" + contextToForward, "");
                     if (contextListToOverwriteDispatch.contains(contextToForward) && !isIgnorePath(dispatchLocation)) {
                         dispatchLocation = "/";
                     }

--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
         <org.wso2.carbon.identity.cors.valve.version>${project.version}</org.wso2.carbon.identity.cors.valve.version>
 
         <!--Carbon identity version-->
-        <identity.framework.version>5.25.358</identity.framework.version>
+        <identity.framework.version>5.25.390-SNAPSHOT</identity.framework.version>
         <carbon.identity.package.import.version.range>[5.17.8, 7.0.0)</carbon.identity.package.import.version.range>
 
         <org.wso2.carbon.identity.oauth.version>6.11.128</org.wso2.carbon.identity.oauth.version>

--- a/pom.xml
+++ b/pom.xml
@@ -345,7 +345,7 @@
         <org.wso2.carbon.identity.cors.valve.version>${project.version}</org.wso2.carbon.identity.cors.valve.version>
 
         <!--Carbon identity version-->
-        <identity.framework.version>5.25.390-SNAPSHOT</identity.framework.version>
+        <identity.framework.version>5.25.393</identity.framework.version>
         <carbon.identity.package.import.version.range>[5.17.8, 7.0.0)</carbon.identity.package.import.version.range>
 
         <org.wso2.carbon.identity.oauth.version>6.11.128</org.wso2.carbon.identity.oauth.version>


### PR DESCRIPTION
### Proposed changes in this pull request

As for now, authorization valve validate whether the authenticated user's tenant domain is same as the accessed tenant qualified resource path. If the request is organization qualified, it will be convert to tenant domain to do the mentioned comparison. 

With this effort, the tenant qualified URLs and organization qualified URLs are treated separately. 

1 - For tenant qualified paths, the previous logic is preserved. 

2 - For organization qualified paths, the organization qualified path and the organization where the token is bound should be same. In order to keep the backward compatibility for organization qualified path (there can be tokens without organization bounded tokens to access organization qualified resources), the previous logic [1] is preserved.

[1] - https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/242/files#diff-5c23026718f023a28a31deb8b3b2d38a1d587c41866b829b28ba63c9a72dc91cR104


Also, the organization bound tokens are allowed to be invoked with the root tenant path. When accessing a resources via root tenant URL path with an organization bound token, an organization scoped tenant flow is started to access only the organization scoped resources.

### Related Issues.
- https://github.com/wso2/product-is/issues/16365

### When should this PR be merged

Depends on
- https://github.com/wso2/carbon-identity-framework/pull/4915