### PR TITLE
Remove redundant cookie hashmap from AuthenticationRequest

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationRequest.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationRequest.java
@@ -57,19 +57,17 @@ public class AuthenticationRequest implements Serializable
 
     private static final Log log = LogFactory.getLog(AuthenticationRequest.class);
 
-    protected Map<String, Object> attributes = new HashMap<>();
-    protected Map<String, String> headers = new HashMap<>();
-    protected Map<CookieKey, Cookie> cookies = new HashMap<>();
-    protected Map<CookieKey, List<Cookie>> cookieListMap = new HashMap<>();
-    protected String contextPath;
-    protected String method;
-    protected String requestUri;
+    private Map<String, Object> attributes = new HashMap<>();
+    private Map<String, String> headers = new HashMap<>();
+    private Map<CookieKey, List<Cookie>> cookieListMap = new HashMap<>();
+    private String contextPath;
+    private String method;
+    private String requestUri;
     private Request request;
 
     protected AuthenticationRequest(AuthenticationRequestBuilder builder) {
         this.attributes = builder.attributes;
         this.headers = builder.headers;
-        this.cookies = builder.cookies;
         this.cookieListMap = builder.cookieListMap;
         this.contextPath = builder.contextPath;
         this.method = builder.method;
@@ -122,11 +120,6 @@ public class AuthenticationRequest implements Serializable
     public void setRequest(Request request) {
 
         this.request = request;
-    }
-
-    @Deprecated
-    public Map<CookieKey, Cookie> getCookieMap() {
-        return Collections.unmodifiableMap(cookies);
     }
 
     public Map<CookieKey, List<Cookie>> getCookieListMap() {

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationRequest.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/AuthenticationRequest.java
@@ -151,7 +151,6 @@ public class AuthenticationRequest implements Serializable
 
         public Map<String, Object> attributes = new HashMap<>();
         private Map<String, String> headers = new HashMap<>();
-        private Map<CookieKey, Cookie> cookies = new HashMap<>();
         private Map<CookieKey, List<Cookie>> cookieListMap = new HashMap<>();
         private String contextPath;
         private String method;
@@ -191,10 +190,6 @@ public class AuthenticationRequest implements Serializable
         }
 
         public AuthenticationRequestBuilder addCookie(CookieKey cookieKey, Cookie value) {
-            if ( this.cookies.containsKey(cookieKey) ) {
-                log.warn("Overriding existing cookie '" + cookieKey.toString() + "' in cookie map");
-            }
-            this.cookies.put(cookieKey, value);
 
             List<Cookie> cookieValues;
             if ( this.cookieListMap.containsKey(cookieKey) ) {


### PR DESCRIPTION
### Proposed changes in this pull request

Since the cookies hash map and its getter method have been deprecated for a while and do not have any usages, it is been removed.
The visibility of other protected variables in the AuthenticationRequest (ex: attributes, and headers) wasreduced to private.

