### PR TITLE
Improve tenant context rewrite regex patterns

### DIFF
--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/RewriteContext.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/RewriteContext.java
@@ -29,11 +29,16 @@ public class RewriteContext {
 
     private Pattern baseContextPattern;
 
+    private static final String CONSOLE_CONTEXT = "/console/";
+
     public RewriteContext(boolean isWebApp, String context) {
 
         this.isWebApp = isWebApp;
         this.context = context;
-        this.tenantContextPattern = Pattern.compile("^/t/([^/]+(?:/o)?)" + context);
+        this.tenantContextPattern = this.isWebApp ? CONSOLE_CONTEXT.equals(context)
+                ? Pattern.compile("^/t/([^/]+)(/o|/o/([^/]+))?" + context)
+                : Pattern.compile("^/t/([^/]+)(/o)?" + context)
+                : Pattern.compile("^/t/([^/]+)" + context);
         this.baseContextPattern = Pattern.compile("^" + context);
     }
 


### PR DESCRIPTION
### Proposed changes in this pull request

```
this.tenantContextPattern = this.isWebApp ? CONSOLE_CONTEXT.equals(context)
                ? Pattern.compile("^/t/([^/]+)(/o|/o/([^/]+))?" + context)
                : Pattern.compile("^/t/([^/]+)(/o)?" + context)
                : Pattern.compile("^/t/([^/]+)" + context);
```
The rewrite context regex patterns should be improved to allow the below URL paths.

1. Tenant perspective API resource access.   - `/t/<tenant-domain>/api/server/v1/applications`
2. Tenant perspective console access - `/t/<tenant-domain>/console`

3. Organization perspective API resource access.   - `/t/<tenant-domain>/o/api/server/v1/applications`
4. Organization perspective console access - `/t/<tenant-domain>/o/<org-id>/console`

The console context `/console/` is separately handled as [here](https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/250/files#diff-5f87b839b0930e2dfd85c5124fad157d139a86a6284ab71c1996c5511fec87a3R38).

The above regex validations only applied for webApps. For servlets, keep the existing regex pattern of
`/t/<tenant-domain>/..`

### Additional information

The organization context rewrite valve will allow organization qualified servlet and some of the specified webApps accesses
ex - `oauth2`

### Related Issues
- https://github.com/wso2/product-is/issues/17120