### PR TITLE
Improve the post authentication handler to set the correct username in the carbon context for organization SSO users

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.service/pom.xml
@@ -187,6 +187,9 @@
                             org.osgi.util.tracker; version="${osgi.util.tracker.imp.pkg.version.range}",
                             org.wso2.carbon.core.*; version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.util; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.common; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.service; version="${carbon.kernel.imp.pkg.version.range}",
+                            org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.utils.*; version="${carbon.kernel.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.common.model.*;
                             version="${carbon.identity.package.import.version.range}"

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
@@ -175,7 +175,7 @@ public abstract class AuthenticationHandler extends AbstractIdentityMessageHandl
                 }
             }
         } catch (OrganizationManagementException | UserStoreException e) {
-            LOG.debug("Authenticated user's username could not be resolved.", e);
+            LOG.error("Authenticated user's username could not be resolved.", e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
@@ -31,9 +31,15 @@ import org.wso2.carbon.identity.auth.service.AuthenticationStatus;
 import org.wso2.carbon.identity.auth.service.exception.AuthClientException;
 import org.wso2.carbon.identity.auth.service.exception.AuthServerException;
 import org.wso2.carbon.identity.auth.service.exception.AuthenticationFailException;
+import org.wso2.carbon.identity.auth.service.internal.AuthenticationServiceHolder;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
 import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
@@ -112,14 +118,11 @@ public abstract class AuthenticationHandler extends AbstractIdentityMessageHandl
                 }
 
                 if (user.getTenantDomain() != null && (user.getTenantDomain()
-                        .equalsIgnoreCase(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()) ||
-                        StringUtils.isNotEmpty(authorizedOrganization))) {
+                        .equalsIgnoreCase(PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()))) {
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(IdentityUtil.addDomainToName
                             (user.getUserName(), user.getUserStoreDomain()));
-                    // Set the user's resident organization if user is accessing an organization
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                            .setUserResidentOrganizationId(userResidentOrganization);
                 }
+
                 // Set the user id to the Carbon context if the user authentication is succeeded.
                 try {
                     AuthenticatedUser authenticatedUser;
@@ -130,16 +133,47 @@ public abstract class AuthenticationHandler extends AbstractIdentityMessageHandl
                             String userName = MultitenantUtils.getTenantAwareUsername(authenticatedUser.getUserName());
                             userName = UserCoreUtil.removeDomainFromName(userName);
                             PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserId(userName);
-                            return;
+                        } else {
+                            PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                                    .setUserId(authenticatedUser.getUserId());
                         }
                     } else {
                         authenticatedUser = new AuthenticatedUser(user);
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserId(authenticatedUser.getUserId());
                     }
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserId(authenticatedUser.getUserId());
                 } catch (UserIdNotFoundException e) {
                     LOG.error("User id not found for user: " + user.getLoggableMaskedUserId());
                 }
+
+                if (StringUtils.isNotEmpty(authorizedOrganization)) {
+                    // Set the user's resident organization if user is accessing an organization
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                            .setUserResidentOrganizationId(userResidentOrganization);
+                    if (((AuthenticatedUser) user).isFederatedUser()) {
+                        updateUserNameInContextForOrganizationSsoUsers(userResidentOrganization);
+                    }
+                }
             }
+        }
+    }
+
+    private void updateUserNameInContextForOrganizationSsoUsers(String userResidentOrganization) {
+
+        try {
+            String tenantDomain = AuthenticationServiceHolder.getInstance().getOrganizationManager()
+                    .resolveTenantDomain(userResidentOrganization);
+            int tenantId = AuthenticationServiceHolder.getInstance().getRealmService().getTenantManager()
+                    .getTenantId(tenantDomain);
+            RealmService realmService = AuthenticationServiceHolder.getInstance().getRealmService();
+            UserRealm tenantUserRealm = realmService.getTenantUserRealm(tenantId);
+            if (tenantUserRealm != null) {
+                String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
+                org.wso2.carbon.user.core.common.User user =
+                        ((AbstractUserStoreManager) tenantUserRealm.getUserStoreManager()).getUser(userId, null);
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(user.getUsername());
+            }
+        } catch (OrganizationManagementException | UserStoreException e) {
+            LOG.debug("Authenticated user's username could not be resolved.", e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
@@ -170,7 +170,9 @@ public abstract class AuthenticationHandler extends AbstractIdentityMessageHandl
                 String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
                 org.wso2.carbon.user.core.common.User user =
                         ((AbstractUserStoreManager) tenantUserRealm.getUserStoreManager()).getUser(userId, null);
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(user.getUsername());
+                if (user != null && StringUtils.isNotEmpty(user.getUsername())) {
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(user.getUsername());
+                }
             }
         } catch (OrganizationManagementException | UserStoreException e) {
             LOG.debug("Authenticated user's username could not be resolved.", e);


### PR DESCRIPTION
### Proposed changes in this pull request

For the organization SSO users, the authentication valve will set the `userID@tenant-domain` as the username. Hence the downstream tasks for using the username which set in the carbon context will fail. One way is to manually handle each places. Ex - https://github.com/wso2/identity-organization-management-core/pull/114 when creating organizations/sharing applications, the correct authenticated username was required to fetch.

Also there are number of places for the MyAccount related functions where username in the carbon context is heavily used. Hence resolving each places and fix for any future features based on the username in the carbon context may not be reliable for the organization users. Hence with this PR, set the correct username in the carbon context.

$subject

### Related issues
- https://github.com/wso2/product-is/issues/17744