### PR TITLE
Allow my account to be accessed by /t/<tenant-domain>/o/<org-id> path

### DIFF
--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/RewriteContext.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/bean/RewriteContext.java
@@ -30,12 +30,14 @@ public class RewriteContext {
     private Pattern baseContextPattern;
 
     private static final String CONSOLE_CONTEXT = "/console/";
+    private static final String MY_ACCOUNT_CONTEXT = "/myaccount/";
 
     public RewriteContext(boolean isWebApp, String context) {
 
         this.isWebApp = isWebApp;
         this.context = context;
-        this.tenantContextPattern = this.isWebApp ? CONSOLE_CONTEXT.equals(context)
+        this.tenantContextPattern = this.isWebApp
+                ? (CONSOLE_CONTEXT.equals(context) || MY_ACCOUNT_CONTEXT.equals(context))
                 ? Pattern.compile("^/t/([^/]+)(/o|/o/([^/]+))?" + context)
                 : Pattern.compile("^/t/([^/]+)(/o)?" + context)
                 : Pattern.compile("^/t/([^/]+)" + context);


### PR DESCRIPTION
### Proposed changes in this pull request
The organization users need to access the myaccount using the `/t/<tenant-domain>/o/<org-id>` path. This PR make it possible.

### Related PRs
This is how same behaviour was provided for the console app.
- https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/250