### PR TITLE
Add capability to validate legacy permissions for certain apis

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -56,4 +56,5 @@ public class Constants {
     public static final String ENABLE_BASIC_AUTH_HANDLER_CONFIG = "EnableBasicAuthHandler";
     public static final String RESOURCE_ACCESS_CONTROL_V2_FILE = "resource-access-control-v2.xml";
     public static final String AUTHENTICATION_TYPE = "authenticationType";
+    public final static String VALIDATE_LEGACY_PERMISSIONS = "validateLegacyPermissions";
 }

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -59,6 +59,7 @@ import javax.servlet.http.HttpServletResponse;
 import static org.wso2.carbon.identity.auth.service.util.Constants.ENGAGED_AUTH_HANDLER;
 import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_ALLOWED_SCOPES;
 import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_VALIDATE_SCOPE;
+import static org.wso2.carbon.identity.auth.service.util.Constants.VALIDATE_LEGACY_PERMISSIONS;
 
 /**
  * AuthenticationValve can be used to intercept any request.
@@ -153,6 +154,8 @@ public class AuthorizationValve extends ValveBase {
                 authorizationContext.setUser(authenticationContext.getUser());
                 authorizationContext.addParameter(OAUTH2_ALLOWED_SCOPES, authenticationContext.getParameter(OAUTH2_ALLOWED_SCOPES));
                 authorizationContext.addParameter(OAUTH2_VALIDATE_SCOPE, authenticationContext.getParameter(OAUTH2_VALIDATE_SCOPE));
+                authorizationContext.addParameter(VALIDATE_LEGACY_PERMISSIONS,
+                        authenticationContext.getParameter(VALIDATE_LEGACY_PERMISSIONS));
 
                 String tenantDomainFromURLMapping = Utils.getTenantDomainFromURLMapping(request);
                 authorizationContext.setTenantDomainFromURLMapping(tenantDomainFromURLMapping);
@@ -238,6 +241,8 @@ public class AuthorizationValve extends ValveBase {
                     authenticationContext.getParameter(OAUTH2_ALLOWED_SCOPES));
             orgMgtAuthorizationContext.addParameter(OAUTH2_VALIDATE_SCOPE,
                     authenticationContext.getParameter(OAUTH2_VALIDATE_SCOPE));
+            orgMgtAuthorizationContext.addParameter(VALIDATE_LEGACY_PERMISSIONS,
+                    authenticationContext.getParameter(VALIDATE_LEGACY_PERMISSIONS));
 
             List<AuthorizationManager> authorizationManagerList = AuthorizationValveServiceHolder.getInstance()
                     .getAuthorizationManagerList();


### PR DESCRIPTION
Related to https://github.com/wso2/product-is/issues/19271

In some cases, we need to validate the legacy permissions.
Ex: the /fileupload/ is a rest api that is used only in the carbon management console and it requires the legacy permission validation.
Authenticators will mark when legacy permission validation is required by setting a parameter in the context. Ex: TomcatCookieAuthenticationHandler which generally authenticates requests coming from the Carbon Management Console.