### PR TITLE
Convert invalid client error log to a debug log

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/BasicClientAuthenticationHandler.java
@@ -137,7 +137,7 @@ public class BasicClientAuthenticationHandler extends AuthenticationHandler {
                         throw new AuthenticationFailException(errorMessage, e);
                     } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
                         String errorMessage = "Invalid client: " + clientId;
-                        log.error(errorMessage, e);
+                        log.debug(errorMessage);
                         throw new AuthenticationFailException(errorMessage, e);
                     }
                 } else {


### PR DESCRIPTION
### Describe:

When invoking introspection endpoint, authentication mechanism is enabled as client credentials, sending invalid client credentials would log a server error. This is converted to a debug log as this is a client side error.

Resolves:
- https://github.com/wso2/product-is/issues/20008