### PR TITLE
Audit log for impersonated resource access

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.service/pom.xml
@@ -71,6 +71,14 @@
             <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -204,6 +212,7 @@
                             org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.exception;
                             version="${identity.event.handler.account.lock.version.range}",
+                            com.nimbusds.jwt; version="${nimbusds.osgi.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.auth.service.internal,

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -57,4 +57,30 @@ public class Constants {
     public static final String RESOURCE_ACCESS_CONTROL_V2_FILE = "resource-access-control-v2.xml";
     public static final String AUTHENTICATION_TYPE = "authenticationType";
     public final static String VALIDATE_LEGACY_PERMISSIONS = "validateLegacyPermissions";
+
+    // Audit Log Constants.
+    public static final String INITIATOR = "Initiator";
+    public static final String ACTION = "Action";
+    public static final String TARGET = "Target";
+    public static final String DATA = "Data";
+    public static final String OUTCOME = "Outcome";
+
+    // Impersonation Constants.
+    public static final String ACT = "act";
+    public static final String SUB = "sub";
+    public static final String GET = "GET";
+    public static final String POST = "POST";
+    public static final String PATCH = "PATCH";
+    public static final String DELETE = "DELETE";
+    public static final String AUTHORIZED = "AUTHORIZED";
+    public static final String IMPERSONATION_RESOURCE_MODIFICATION = "resource-modification-via-impersonation";
+    public static final String IMPERSONATION_RESOURCE_ACCESS = "resource-access-via-impersonation";
+    public static final String IMPERSONATION_RESOURCE_DELETION = "resource-deletion-via-impersonation";
+    public static final String IMPERSONATION_RESOURCE_CREATION = "resource-creation-via-impersonation";
+    public static final String SUBJECT = "subject";
+    public static final String IMPERSONATOR = "impersonator";
+    public static final String RESOURCE_PATH = "ResourcePath";
+    public static final String HTTP_METHOD = "httpMethod";
+    public static final String CLIENT_ID = "clientId";
+    public static final String SCOPE = "scope";
 }

--- a/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java
+++ b/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java
@@ -78,6 +78,7 @@ public class AuthenticationValve extends ValveBase {
     private static final String USER_AGENT = "User-Agent";
     private static final String REMOTE_ADDRESS = "remoteAddress";
     private static final String SERVICE_PROVIDER = "serviceProvider";
+    private static final String IMPERSONATOR = "impersonator";
     private final String CLIENT_COMPONENT = "clientComponent";
     private final String REST_API_CLIENT_COMPONENT = "REST API";
     private static final String AUTH_USER_TENANT_DOMAIN = "authUserTenantDomain";
@@ -275,6 +276,7 @@ public class AuthenticationValve extends ValveBase {
         MDC.remove(USER_AGENT);
         MDC.remove(REMOTE_ADDRESS);
         MDC.remove(SERVICE_PROVIDER);
+        MDC.remove(IMPERSONATOR);
     }
 
     private boolean isLoggableParam(String param) {

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
                 <version>${json.wso2.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.orbit.com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbusds.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.management.authz.service</artifactId>
                 <version>${org.wso2.carbon.identity.organization.management.version}</version>
@@ -356,6 +361,9 @@
         <org.wso2.carbon.identity.oauth.version>7.0.18</org.wso2.carbon.identity.oauth.version>
         <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 8.0.0)
         </org.wso2.carbon.identity.oauth.import.version.range>
+
+        <nimbusds.version>7.9.0.wso2v1</nimbusds.version>
+        <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
 
         <org.wso2.carbon.identity.organization.management.version>1.1.14
         </org.wso2.carbon.identity.organization.management.version>


### PR DESCRIPTION
Public Issue: https://github.com/wso2/product-is/issues/20066

## Purpose
Add audit log for impersonated resource access.

## Approach
Once authorised we inspect the token whether its impersonated or not, then log the details.

sample log
```
TID: [-1234] [2024-04-29 12:08:51,718] [096205f0-67f6-49b6-bec3-eba6f4e82369]  INFO {AUDIT_LOG} - Initiator=d9982d93-4e73-4565-b7ac-3605e8d05f80 (id of the user B)Action=resource-modification-via-impersonation Target=8122e3de-0f3b-4b0e-a43a-d0c237451b7a Data={"ResourcePath":"/scim2/Me","clientId":"xnygcXs9Z4L5fhhfDY9MCcnUwxQa","scope":"internal_login internal_user_mgt_list internal_user_mgt_view openid","subject":"8122e3de-0f3b-4b0e-a43a-d0c237451b7a","impersonator":"d9982d93-4e73-4565-b7ac-3605e8d05f80","httpMethod":"PATCH"} Outcome=AUTHORIZED
```