### PR TITLE
Change error log to debug log when fails to resolve the OAuth app by client ID when introspecting the access token

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -173,8 +173,10 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                             OAuth2Util.getServiceProvider(oAuth2IntrospectionResponseDTO.getClientId()).
                                     getApplicationName();
                 } catch (IdentityOAuth2Exception e) {
-                    log.error("Error occurred while getting the Service Provider by Consumer key: "
-                            + oAuth2IntrospectionResponseDTO.getClientId(), e);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error occurred while getting the Service Provider by Consumer key: "
+                                + oAuth2IntrospectionResponseDTO.getClientId(), e);
+                    }
                 }
 
                 String serviceProviderTenantDomain = null;

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -182,8 +182,10 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                     serviceProviderTenantDomain =
                             OAuth2Util.getTenantDomainOfOauthApp(oAuth2IntrospectionResponseDTO.getClientId());
                 } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
-                    log.error("Error occurred while getting the OAuth App tenantDomain by Consumer key: "
-                            + oAuth2IntrospectionResponseDTO.getClientId(), e);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error occurred while getting the OAuth App tenantDomain by Consumer key: "
+                                + oAuth2IntrospectionResponseDTO.getClientId(), e);
+                    }
                 }
 
                 if (serviceProvider != null) {


### PR DESCRIPTION
### Proposed changes in this pull request

The SP is added to the thread local by this fix - https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/121
From that onwards, there may be downstream task which fails to process when the SP is not found in the thread local.

But not having SP in the thread local will cause an error for that consuming logic, hence logging an error may not be required in this place.