### PR TITLE
Add support to access organization resources in tenant perspective

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/pom.xml
+++ b/components/org.wso2.carbon.identity.auth.service/pom.xml
@@ -20,7 +20,7 @@
         <groupId>org.wso2.carbon.identity.auth.rest</groupId>
         <artifactId>identity-carbon-auth-rest</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.9.15-SNAPSHOT</version>
+        <version>1.9.14</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -215,6 +215,7 @@
                             version="${org.wso2.carbon.identity.oauth.import.version.range}",
                             org.wso2.carbon.identity.organization.management.service; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.constant; version="${org.wso2.carbon.identity.organization.management.core.version.range}",
                             org.wso2.carbon.identity.handler.event.account.lock.exception;
                             version="${identity.event.handler.account.lock.version.range}",
                             com.nimbusds.jwt; version="${nimbusds.osgi.version.range}",

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -57,6 +57,7 @@ import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.RefreshTokenValidator;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 
 import java.text.ParseException;
 import java.util.Arrays;
@@ -176,18 +177,18 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                 ServiceProvider serviceProvider = null;
                 String serviceProviderName = null;
                 String serviceProviderUUID = null;
-                String accessingTenantDomain = null;
+                String applicationResidentTenantDomain = null;
                 try {
                     // Getting the accessing tenant domain from the authenticated user through the introspection
                     // response where the token is introspected.
                     if (authorizedUser != null) {
-                        accessingTenantDomain = authorizedUser.getTenantDomain();
+                        applicationResidentTenantDomain = authorizedUser.getTenantDomain();
                         serviceProvider = OAuth2Util.getServiceProvider(
-                                oAuth2IntrospectionResponseDTO.getClientId(), accessingTenantDomain);
-                        boolean isSharedApp = Arrays.stream(serviceProvider.getSpProperties()).anyMatch(
+                                oAuth2IntrospectionResponseDTO.getClientId(), applicationResidentTenantDomain);
+                        boolean isB2BSharedApp = Arrays.stream(serviceProvider.getSpProperties()).anyMatch(
                                 property -> "isAppShared".equals(property.getName()) &&
                                         Boolean.parseBoolean(property.getValue()));
-                        authenticationContext.addParameter("isAppShared", isSharedApp);
+                        authenticationContext.addParameter("isB2BAppShared", isB2BSharedApp);
                     } else {
                         serviceProvider = OAuth2Util.getServiceProvider(oAuth2IntrospectionResponseDTO.getClientId());
                     }
@@ -209,10 +210,10 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
 
                 String serviceProviderTenantDomain = null;
                 try {
-                    if (StringUtils.isNotEmpty(accessingTenantDomain)) {
+                    if (StringUtils.isNotEmpty(applicationResidentTenantDomain)) {
                         serviceProviderTenantDomain =
                                 OAuth2Util.getTenantDomainOfOauthApp(oAuth2IntrospectionResponseDTO.getClientId(),
-                                        accessingTenantDomain);
+                                        applicationResidentTenantDomain);
                     } else {
                         serviceProviderTenantDomain =
                                 OAuth2Util.getTenantDomainOfOauthApp(oAuth2IntrospectionResponseDTO.getClientId());

--- a/components/org.wso2.carbon.identity.authz.valve/pom.xml
+++ b/components/org.wso2.carbon.identity.authz.valve/pom.xml
@@ -20,7 +20,7 @@
         <groupId>org.wso2.carbon.identity.auth.rest</groupId>
         <artifactId>identity-carbon-auth-rest</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.9.15-SNAPSHOT</version>
+        <version>1.9.14</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -100,6 +100,7 @@
                             org.wso2.carbon.identity.authz.service.*;version="${org.wso2.carbon.identity.authz.service.version.range}",
                             org.apache.catalina.*;version="1.7.0",
                             org.wso2.carbon.identity.organization.management.authz.service; version="${org.wso2.carbon.identity.organization.management.version.range}",
+                            org.wso2.carbon.identity.organization.management.authz.service.util; version="${org.wso2.carbon.identity.organization.management.version.range}",
                             org.wso2.carbon.identity.organization.management.service.constant; version="${org.wso2.carbon.identity.organization.management.core.version.range}"
                         </Import-Package>
                         <Export-Package>!org.wso2.carbon.identity.authz.valve.internal,

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -235,7 +235,11 @@ public class AuthorizationValve extends ValveBase {
     private boolean isRequestValidForTenant(AuthenticationContext authenticationContext,
                                             AuthorizationContext authorizationContext, Request request) {
 
-        return (Utils.isUserBelongsToRequestedTenant(authenticationContext, request) ||
+        boolean isSubOrgApp = false;
+        if (authenticationContext.getParameter("isSubOrgApp") != null) {
+            isSubOrgApp = Boolean.parseBoolean(authenticationContext.getParameter("isSubOrgApp").toString());
+        }
+        return (Utils.isUserBelongsToRequestedTenant(authenticationContext, request) || isSubOrgApp ||
                 (authorizationContext.isCrossTenantAllowed()) &&
                         Utils.isTenantBelongsToAllowedCrossTenant(authenticationContext, authorizationContext));
     }

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/pom.xml
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/pom.xml
@@ -20,7 +20,7 @@
         <groupId>org.wso2.carbon.identity.auth.rest</groupId>
         <artifactId>identity-carbon-auth-rest</artifactId>
         <relativePath>../../pom.xml</relativePath>
-        <version>1.9.15-SNAPSHOT</version>
+        <version>1.9.14</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
@@ -23,6 +23,7 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -30,6 +31,7 @@ import org.slf4j.MDC;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.context.rewrite.bean.OrganizationRewriteContext;
 import org.wso2.carbon.identity.context.rewrite.bean.RewriteContext;
 import org.wso2.carbon.identity.context.rewrite.internal.ContextRewriteValveServiceComponentHolder;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
@@ -41,8 +43,10 @@ import org.wso2.carbon.user.core.tenant.TenantManager;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
@@ -59,6 +63,7 @@ import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.TENANT_NA
 public class TenantContextRewriteValve extends ValveBase {
 
     private static List<RewriteContext> contextsToRewrite;
+    private static List<OrganizationRewriteContext> contextsToRewriteInTenantPerspective;
     private static List<String> contextListToOverwriteDispatch;
     private static List<String> ignorePathListForOverwriteDispatch;
     private static List<String> organizationRoutingOnlySupportedAPIPaths;
@@ -73,6 +78,7 @@ public class TenantContextRewriteValve extends ValveBase {
         super.startInternal();
         // Initialize the tenant context rewrite valve.
         contextsToRewrite = getContextsToRewrite();
+        contextsToRewriteInTenantPerspective = getContextsToRewriteInTenantPerspective();
         contextListToOverwriteDispatch = getContextListToOverwriteDispatchLocation();
         ignorePathListForOverwriteDispatch = getIgnorePathListForOverwriteDispatch();
         isTenantQualifiedUrlsEnabled = isTenantQualifiedUrlsEnabled();
@@ -110,6 +116,26 @@ public class TenantContextRewriteValve extends ValveBase {
             }
         }
 
+        outerLoop:
+        for (OrganizationRewriteContext context : contextsToRewriteInTenantPerspective) {
+            Pattern patternTenantPerspective = Pattern.compile("^/t/[^/]+/o/[a-f0-9\\-]+?" + context.getContext());
+            if (patternTenantPerspective.matcher(requestURI).find() && CollectionUtils.isNotEmpty(context.getSubPaths())) {
+                for (Pattern subPath : context.getSubPaths()) {
+                    if (subPath.matcher(requestURI).find()) {
+                        isContextRewrite = true;
+                        isWebApp = context.isWebApp();
+                        contextToForward = context.getContext();
+                        int startIndex = requestURI.indexOf("/o/") + 3;
+                        int endIndex = requestURI.indexOf("/", startIndex);
+                        String appOrgId = requestURI.substring(startIndex, endIndex);
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().
+                                setApplicationResidentOrganizationId(appOrgId);
+                        break outerLoop;
+                    }
+                }
+            }
+        }
+
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         try {
             MDC.put(TENANT_DOMAIN, tenantDomain);
@@ -135,7 +161,8 @@ public class TenantContextRewriteValve extends ValveBase {
                      Ex-: Request: /t/<tenant-domain>/o/api/server/v1/applications  -->  /o/server/v1/applications
                      */
                     if (!requestURI.startsWith(ORGANIZATION_PATH_PARAM) &&
-                            requestURI.contains(ORGANIZATION_PATH_PARAM)) {
+                            requestURI.contains(ORGANIZATION_PATH_PARAM) &&
+                            !isOrganizationIdAvailableInTenantPerspective(requestURI)) {
                         dispatchLocation = "/o" + dispatchLocation;
                     }
                     if (contextListToOverwriteDispatch.contains(contextToForward) && !isIgnorePath(dispatchLocation)) {
@@ -151,7 +178,10 @@ public class TenantContextRewriteValve extends ValveBase {
                         requestURI = requestURI.replace(carbonWebContext + "/", "");
                     }
                     //Servlet
-                    requestURI = requestURI.replace("/t/" + tenantDomain, "");
+                    if (StringUtils.isEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                            .getApplicationResidentOrganizationId())) {
+                        requestURI = requestURI.replace("/t/" + tenantDomain, "");
+                    }
                     request.getRequestDispatcher(requestURI).forward(request, response);
                 }
             }
@@ -174,6 +204,11 @@ public class TenantContextRewriteValve extends ValveBase {
             IdentityUtil.threadLocalProperties.get().remove(TENANT_NAME_FROM_CONTEXT);
             unsetMDCThreadLocals();
         }
+    }
+
+    private boolean isOrganizationIdAvailableInTenantPerspective(String requestURI) {
+
+        return Pattern.compile("^/t/[^/]+/o/[a-f0-9\\-]+?").matcher(requestURI).find();
     }
 
     private void unsetMDCThreadLocals() {
@@ -215,6 +250,51 @@ public class TenantContextRewriteValve extends ValveBase {
             }
         }
         return rewriteContexts;
+    }
+
+    private List<OrganizationRewriteContext> getContextsToRewriteInTenantPerspective() {
+
+        List<OrganizationRewriteContext> organizationRewriteContexts = new ArrayList<>();
+        Map<String, Object> configuration = IdentityConfigParser.getInstance().getConfiguration();
+        Object webAppBasePathContexts = configuration.get("OrgContextsToRewriteInTenantPerspective.WebApp.Context." +
+                "BasePath");
+        setOrganizationRewriteContexts(organizationRewriteContexts, webAppBasePathContexts, true);
+
+        Object webAppSubPathContexts = configuration.get("OrgContextsToRewriteInTenantPerspective.WebApp.Context." +
+                "SubPaths.Path");
+        setSubPathContexts(organizationRewriteContexts, webAppSubPathContexts);
+
+        return organizationRewriteContexts;
+    }
+
+    private void setOrganizationRewriteContexts(List<OrganizationRewriteContext> organizationRewriteContexts,
+                                                Object basePathContexts, boolean isWebApp) {
+
+        if (basePathContexts != null) {
+            if (basePathContexts instanceof ArrayList) {
+                for (String context : (ArrayList<String>) basePathContexts) {
+                    organizationRewriteContexts.add(new OrganizationRewriteContext(isWebApp, context));
+                }
+            } else {
+                organizationRewriteContexts.add(new OrganizationRewriteContext(isWebApp,
+                        basePathContexts.toString()));
+            }
+        }
+    }
+
+    private void setSubPathContexts(List<OrganizationRewriteContext> organizationRewriteContexts,
+                                    Object subPathContexts) {
+
+        if (subPathContexts instanceof ArrayList) {
+            for (String subPath : (ArrayList<String>) subPathContexts) {
+                Optional<OrganizationRewriteContext> maybeOrgRewriteContext = organizationRewriteContexts.stream()
+                        .filter(rewriteContext -> subPath.startsWith(rewriteContext.getContext()))
+                        .max(Comparator.comparingInt(rewriteContext -> rewriteContext.getContext().length()));
+                maybeOrgRewriteContext.ifPresent(
+                        organizationRewriteContext -> organizationRewriteContext.addSubPath(
+                                Pattern.compile("^/t/[^/]+/o/[a-f0-9\\-]+" + subPath)));
+            }
+        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -452,8 +452,8 @@
         <osgi.util.tracker.imp.pkg.version.range>[1.5.1, 2.0.0)</osgi.util.tracker.imp.pkg.version.range>
 
         <!-- Carbon Kernel version -->
-        <carbon.kernel.version>4.9.17</carbon.kernel.version>
-        <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
+        <carbon.kernel.version>4.10.25</carbon.kernel.version>
+        <carbon.kernel.feature.version>4.10.0</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version.range>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
 
         <!--Carbon Component version-->

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
         <identity.framework.version>7.3.13</identity.framework.version>
         <carbon.identity.package.import.version.range>[5.17.8, 8.0.0)</carbon.identity.package.import.version.range>
 
-        <org.wso2.carbon.identity.oauth.version>7.0.65</org.wso2.carbon.identity.oauth.version>
+        <org.wso2.carbon.identity.oauth.version>7.0.192</org.wso2.carbon.identity.oauth.version>
         <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 8.0.0)
         </org.wso2.carbon.identity.oauth.import.version.range>
 
@@ -452,7 +452,7 @@
         <osgi.util.tracker.imp.pkg.version.range>[1.5.1, 2.0.0)</osgi.util.tracker.imp.pkg.version.range>
 
         <!-- Carbon Kernel version -->
-        <carbon.kernel.version>4.10.25</carbon.kernel.version>
+        <carbon.kernel.version>4.10.26</carbon.kernel.version>
         <carbon.kernel.feature.version>4.10.0</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version.range>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
         </org.wso2.carbon.identity.organization.management.version>
         <org.wso2.carbon.identity.organization.management.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.version.range>
-        <org.wso2.carbon.identity.organization.management.core.version>1.0.85
+        <org.wso2.carbon.identity.organization.management.core.version>1.1.19
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- Improvement for : https://github.com/wso2/product-is/issues/21208
- From this fix the organization related APIs can be executed from the tenant perspective for the allowed endpoints which are configured as follows.
```
<OrgContextsToRewriteInTenantPerspective>
    <WebApp>
        <Context>
            <BasePath>/api/</BasePath>
            <SubPaths>
                <Path>/api/identity/oauth2/dcr/</Path>
            </SubPaths>
        </Context>
        <Context>
            <BasePath>/oauth2/</BasePath>
            <SubPaths>
                <Path>/oauth2/token</Path>
                <Path>/oauth2/introspect</Path>
            </SubPaths>
        </Context>
    </WebApp>
</OrgContextsToRewriteInTenantPerspective>
```
- DCR endpoint will create the OAuth2 applications in the sub organization level
   - Path : `/t/{tenant-domain}/o/{org-id}/api/identity/oauth2/dcr/v1.1/register`
- Token generation and introspection
   - Path : `/t/{tenant-domain}/o/{org-id}/oauth2/token?scope=openid ...`
- When access tokens are handled the tokens will be handled from the sub organization level by checking the type of the application which are using the token service.

### When should this PR be merged

- This PR needs to be merged once a new kernel version is released with the changes in : https://github.com/wso2/carbon-kernel/pull/4104