### PR TITLE
Allow access to the tenant perspective APIs

### DIFF
--- a/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
+++ b/components/org.wso2.carbon.identity.context.rewrite.valve/src/main/java/org/wso2/carbon/identity/context/rewrite/valve/TenantContextRewriteValve.java
@@ -23,6 +23,7 @@ import org.apache.catalina.LifecycleException;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -30,6 +31,7 @@ import org.slf4j.MDC;
 import org.wso2.carbon.base.ServerConfiguration;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.base.IdentityRuntimeException;
+import org.wso2.carbon.identity.context.rewrite.bean.OrganizationRewriteContext;
 import org.wso2.carbon.identity.context.rewrite.bean.RewriteContext;
 import org.wso2.carbon.identity.context.rewrite.internal.ContextRewriteValveServiceComponentHolder;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
@@ -41,8 +43,10 @@ import org.wso2.carbon.user.core.tenant.TenantManager;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import javax.servlet.ServletException;
@@ -59,6 +63,7 @@ import static org.wso2.carbon.identity.core.util.IdentityCoreConstants.TENANT_NA
 public class TenantContextRewriteValve extends ValveBase {
 
     private static List<RewriteContext> contextsToRewrite;
+    private static List<OrganizationRewriteContext> contextsToRewriteInTenantPerspective;
     private static List<String> contextListToOverwriteDispatch;
     private static List<String> ignorePathListForOverwriteDispatch;
     private static List<String> organizationRoutingOnlySupportedAPIPaths;
@@ -73,6 +78,7 @@ public class TenantContextRewriteValve extends ValveBase {
         super.startInternal();
         // Initialize the tenant context rewrite valve.
         contextsToRewrite = getContextsToRewrite();
+        contextsToRewriteInTenantPerspective = getContextsToRewriteInTenantPerspective();
         contextListToOverwriteDispatch = getContextListToOverwriteDispatchLocation();
         ignorePathListForOverwriteDispatch = getIgnorePathListForOverwriteDispatch();
         isTenantQualifiedUrlsEnabled = isTenantQualifiedUrlsEnabled();
@@ -110,6 +116,26 @@ public class TenantContextRewriteValve extends ValveBase {
             }
         }
 
+        outerLoop:
+        for (OrganizationRewriteContext context : contextsToRewriteInTenantPerspective) {
+            Pattern patternTenantPerspective = Pattern.compile("^/t/[^/]+/o/[a-f0-9\\-]+?" + context.getContext());
+            if (patternTenantPerspective.matcher(requestURI).find() && CollectionUtils.isNotEmpty(context.getSubPaths())) {
+                for (Pattern subPath : context.getSubPaths()) {
+                    if (subPath.matcher(requestURI).find()) {
+                        isContextRewrite = true;
+                        isWebApp = context.isWebApp();
+                        contextToForward = context.getContext();
+                        int startIndex = requestURI.indexOf("/o/") + 3;
+                        int endIndex = requestURI.indexOf("/", startIndex);
+                        String appOrgId = requestURI.substring(startIndex, endIndex);
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().
+                                setApplicationResidentOrganizationId(appOrgId);
+                        break outerLoop;
+                    }
+                }
+            }
+        }
+
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         try {
             MDC.put(TENANT_DOMAIN, tenantDomain);
@@ -135,7 +161,8 @@ public class TenantContextRewriteValve extends ValveBase {
                      Ex-: Request: /t/<tenant-domain>/o/api/server/v1/applications  -->  /o/server/v1/applications
                      */
                     if (!requestURI.startsWith(ORGANIZATION_PATH_PARAM) &&
-                            requestURI.contains(ORGANIZATION_PATH_PARAM)) {
+                            requestURI.contains(ORGANIZATION_PATH_PARAM) &&
+                            !isOrganizationIdAvailableInTenantPerspective(requestURI)) {
                         dispatchLocation = "/o" + dispatchLocation;
                     }
                     if (contextListToOverwriteDispatch.contains(contextToForward) && !isIgnorePath(dispatchLocation)) {
@@ -151,7 +178,10 @@ public class TenantContextRewriteValve extends ValveBase {
                         requestURI = requestURI.replace(carbonWebContext + "/", "");
                     }
                     //Servlet
-                    requestURI = requestURI.replace("/t/" + tenantDomain, "");
+                    if (StringUtils.isEmpty(PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                            .getApplicationResidentOrganizationId())) {
+                        requestURI = requestURI.replace("/t/" + tenantDomain, "");
+                    }
                     request.getRequestDispatcher(requestURI).forward(request, response);
                 }
             }
@@ -310,5 +340,55 @@ public class TenantContextRewriteValve extends ValveBase {
             String errorPage = ContextRewriteValveServiceComponentHolder.getInstance().getPageNotFoundErrorPage();
             response.getWriter().print(errorPage);
         }
+    }
+
+    private List<OrganizationRewriteContext> getContextsToRewriteInTenantPerspective() {
+
+        List<OrganizationRewriteContext> organizationRewriteContexts = new ArrayList<>();
+        Map<String, Object> configuration = IdentityConfigParser.getInstance().getConfiguration();
+        Object webAppBasePathContexts = configuration.get("OrgContextsToRewriteInTenantPerspective.WebApp.Context." +
+                "BasePath");
+        setOrganizationRewriteContexts(organizationRewriteContexts, webAppBasePathContexts, true);
+
+        Object webAppSubPathContexts = configuration.get("OrgContextsToRewriteInTenantPerspective.WebApp.Context." +
+                "SubPaths.Path");
+        setSubPathContexts(organizationRewriteContexts, webAppSubPathContexts);
+
+        return organizationRewriteContexts;
+    }
+
+    private void setOrganizationRewriteContexts(List<OrganizationRewriteContext> organizationRewriteContexts,
+                                                Object basePathContexts, boolean isWebApp) {
+
+        if (basePathContexts != null) {
+            if (basePathContexts instanceof ArrayList) {
+                for (String context : (ArrayList<String>) basePathContexts) {
+                    organizationRewriteContexts.add(new OrganizationRewriteContext(isWebApp, context));
+                }
+            } else {
+                organizationRewriteContexts.add(new OrganizationRewriteContext(isWebApp,
+                        basePathContexts.toString()));
+            }
+        }
+    }
+
+    private void setSubPathContexts(List<OrganizationRewriteContext> organizationRewriteContexts,
+                                    Object subPathContexts) {
+
+        if (subPathContexts instanceof ArrayList) {
+            for (String subPath : (ArrayList<String>) subPathContexts) {
+                Optional<OrganizationRewriteContext> maybeOrgRewriteContext = organizationRewriteContexts.stream()
+                        .filter(rewriteContext -> subPath.startsWith(rewriteContext.getContext()))
+                        .max(Comparator.comparingInt(rewriteContext -> rewriteContext.getContext().length()));
+                maybeOrgRewriteContext.ifPresent(
+                        organizationRewriteContext -> organizationRewriteContext.addSubPath(
+                                Pattern.compile("^/t/[^/]+/o/[a-f0-9\\-]+" + subPath)));
+            }
+        }
+    }
+
+    private boolean isOrganizationIdAvailableInTenantPerspective(String requestURI) {
+
+        return Pattern.compile("^/t/[^/]+/o/[a-f0-9\\-]+?").matcher(requestURI).find();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
         <osgi.util.tracker.imp.pkg.version.range>[1.5.1, 2.0.0)</osgi.util.tracker.imp.pkg.version.range>
 
         <!-- Carbon Kernel version -->
-        <carbon.kernel.version>4.9.17</carbon.kernel.version>
+        <carbon.kernel.version>4.10.26</carbon.kernel.version>
         <carbon.kernel.feature.version>4.9.0</carbon.kernel.feature.version>
         <carbon.kernel.imp.pkg.version.range>[4.5.0, 5.0.0)</carbon.kernel.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- Improvement for : https://github.com/wso2/product-is/issues/21208
- From this fix the organization related APIs can be executed from the tenant perspective for the allowed endpoints which are configured as follows.
```
<OrgContextsToRewriteInTenantPerspective>
    <WebApp>
        <Context>
            <BasePath>/api/</BasePath>
            <SubPaths>
                <Path>/api/identity/oauth2/dcr/</Path>
            </SubPaths>
        </Context>
        <Context>
            <BasePath>/oauth2/</BasePath>
            <SubPaths>
                <Path>/oauth2/token</Path>
                <Path>/oauth2/introspect</Path>
            </SubPaths>
        </Context>
    </WebApp>
</OrgContextsToRewriteInTenantPerspective>
```
- DCR endpoint will create the OAuth2 applications in the sub organization level
   - Path : `/t/{tenant-domain}/o/{org-id}/api/identity/oauth2/dcr/v1.1/register`
- Token generation and introspection
   - Path : `/t/{tenant-domain}/o/{org-id}/oauth2/token?scope=openid ...`
- When access tokens are handled the tokens will be handled from the sub organization level by checking the type of the application which are using the token service.

### When should this PR be merged

- This PR needs to be merged once a new kernel version is released with the changes in : https://github.com/wso2/carbon-kernel/pull/4104