### PR TITLE
Improve authorization when accessing the organization resources from tenant perspective

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -55,6 +55,7 @@ public class Constants {
     public static final String BASIC_AUTHENTICATION = "BasicAuthentication";
     public static final String ENABLE_BASIC_AUTH_HANDLER_CONFIG = "EnableBasicAuthHandler";
     public static final String RESOURCE_ACCESS_CONTROL_V2_FILE = "resource-access-control-v2.xml";
+    public final static String RESOURCE_ORGANIZATION_ID = "resourceOrgId";
     public static final String AUTHENTICATION_TYPE = "authenticationType";
     public final static String VALIDATE_LEGACY_PERMISSIONS = "validateLegacyPermissions";
 

--- a/components/org.wso2.carbon.identity.authz.service/pom.xml
+++ b/components/org.wso2.carbon.identity.authz.service/pom.xml
@@ -59,6 +59,14 @@
             <artifactId>org.wso2.carbon.identity.auth.service</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jacoco</groupId>
             <artifactId>jacoco-maven-plugin</artifactId>
             <version>${jacoco.version}</version>
@@ -94,7 +102,9 @@
                             org.wso2.carbon.identity.core.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.oauth2.*;
                             version="${org.wso2.carbon.identity.oauth.import.version.range}",
-                            org.wso2.carbon.identity.auth.service.*;version="${org.wso2.carbon.identity.auth.service.version.range}"
+                            org.wso2.carbon.identity.auth.service.*;version="${org.wso2.carbon.identity.auth.service.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing.*;
+                            version="${org.wso2.carbon.identity.organization.management.version.range}",
                         </Import-Package>
                         <Export-Package>
                             !org.wso2.carbon.identity.authz.service.internal,

--- a/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/internal/AuthorizationServiceComponent.java
+++ b/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/internal/AuthorizationServiceComponent.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.authz.service.AuthorizationManager;
 import org.wso2.carbon.identity.authz.service.handler.AuthorizationHandler;
 import org.wso2.carbon.identity.authz.service.handler.ResourceHandler;
 import org.wso2.carbon.identity.core.handler.HandlerComparator;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 import java.util.Collections;
 import java.util.List;
@@ -114,6 +115,25 @@ public class AuthorizationServiceComponent {
 
     protected void unsetResourceHandler(ResourceHandler resourceHandler) {
         setResourceHandler(null);
+    }
+
+    @Reference(
+            name = "organization.service",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager"
+    )
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        log.debug("Setting the organization management service.");
+        AuthorizationServiceHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        log.debug("Unset organization management service.");
+        AuthorizationServiceHolder.getInstance().setOrganizationManager(null);
     }
 }
 

--- a/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/internal/AuthorizationServiceHolder.java
+++ b/components/org.wso2.carbon.identity.authz.service/src/main/java/org/wso2/carbon/identity/authz/service/internal/AuthorizationServiceHolder.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.authz.service.internal;
 
 import org.wso2.carbon.identity.authz.service.handler.AuthorizationHandler;
 import org.wso2.carbon.identity.authz.service.handler.ResourceHandler;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ public class AuthorizationServiceHolder {
     private List<ResourceHandler> resourceHandlerList = new ArrayList<>();
 
     private RealmService realmService = null;
+    private OrganizationManager organizationManager;
 
     private AuthorizationServiceHolder() {
 
@@ -60,5 +62,15 @@ public class AuthorizationServiceHolder {
 
     public List<ResourceHandler> getResourceHandlerList() {
         return resourceHandlerList;
+    }
+
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
     }
 }

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/AuthorizationValve.java
@@ -59,6 +59,7 @@ import javax.servlet.http.HttpServletResponse;
 import static org.wso2.carbon.identity.auth.service.util.Constants.ENGAGED_AUTH_HANDLER;
 import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_ALLOWED_SCOPES;
 import static org.wso2.carbon.identity.auth.service.util.Constants.OAUTH2_VALIDATE_SCOPE;
+import static org.wso2.carbon.identity.auth.service.util.Constants.RESOURCE_ORGANIZATION_ID;
 import static org.wso2.carbon.identity.auth.service.util.Constants.VALIDATE_LEGACY_PERMISSIONS;
 
 /**
@@ -122,6 +123,13 @@ public class AuthorizationValve extends ValveBase {
                 authorizationContext.addParameter(OAUTH2_VALIDATE_SCOPE, authenticationContext.getParameter(OAUTH2_VALIDATE_SCOPE));
                 authorizationContext.addParameter(VALIDATE_LEGACY_PERMISSIONS,
                         authenticationContext.getParameter(VALIDATE_LEGACY_PERMISSIONS));
+                Pattern patternTenantPerspective = Pattern.compile("^/t/[^/]+/o/[a-f0-9\\-]+?");
+                if (patternTenantPerspective.matcher(requestURI).find()) {
+                    int startIndex = requestURI.indexOf("/o/") + 3;
+                    int endIndex = requestURI.indexOf("/", startIndex);
+                    String resourceOrgId = requestURI.substring(startIndex, endIndex);
+                    authorizationContext.addParameter(RESOURCE_ORGANIZATION_ID, resourceOrgId);
+                }
 
                 String tenantDomainFromURLMapping = Utils.getTenantDomainFromURLMapping(request);
                 authorizationContext.setTenantDomainFromURLMapping(tenantDomainFromURLMapping);

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,11 @@
                 <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
                 <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
                 <version>${identity.event.handler.account.lock.version}</version>
@@ -437,7 +442,7 @@
         <nimbusds.version>7.9.0.wso2v1</nimbusds.version>
         <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
 
-        <org.wso2.carbon.identity.organization.management.version>1.1.14
+        <org.wso2.carbon.identity.organization.management.version>1.4.59
         </org.wso2.carbon.identity.organization.management.version>
         <org.wso2.carbon.identity.organization.management.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.version.range>


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- Part of the fix for : https://github.com/wso2/product-is/issues/21208
- When accessing the resources or an organization through tenant perspective, the accessing or authenticated user should have access in the sub organization level.
- To give the access in the sub organization level to the corresponding user, a shared user representation should be maintain in the sub organization level and correspoding permissions should assigned to that shared user representation.
- This implementation will check those conditions and allow the access.