### PR TITLE
Allow sub organization applications to consume tokens from the valve level

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -55,6 +55,8 @@ import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.token.bindings.TokenBinding;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.identity.oauth2.validators.RefreshTokenValidator;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 
 import java.text.ParseException;
 import java.util.Map;
@@ -147,8 +149,10 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                 authenticationResult.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
 
                 User authorizedUser = oAuth2IntrospectionResponseDTO.getAuthorizedUser();
+                String authorizedUserTenantDomain = null;
                 if (authorizedUser != null) {
                     authenticationContext.setUser(authorizedUser);
+                    authorizedUserTenantDomain = authorizedUser.getTenantDomain();
                     if (authorizedUser instanceof AuthenticatedUser) {
                         IdentityUtil.threadLocalProperties.get()
                                 .put(Constants.IS_FEDERATED_USER,
@@ -174,7 +178,18 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                 String serviceProviderName = null;
                 String serviceProviderUUID = null;
                 try {
-                    serviceProvider = OAuth2Util.getServiceProvider(oAuth2IntrospectionResponseDTO.getClientId());
+                    /*
+                     Tokens which are issued for the applications which are registered in sub organization,
+                     contains the tenant domain for the authorized user as the sub organization. Based on that
+                     we can get the application details by using both the client id and the tenant domain.
+                    */
+                    if (StringUtils.isNotEmpty(authorizedUserTenantDomain) && OrganizationManagementUtil.
+                            isOrganization(authorizedUserTenantDomain)) {
+                        serviceProvider = OAuth2Util.getServiceProvider(oAuth2IntrospectionResponseDTO.getClientId(),
+                                authorizedUserTenantDomain);
+                    } else {
+                        serviceProvider = OAuth2Util.getServiceProvider(oAuth2IntrospectionResponseDTO.getClientId());
+                    }
                     if (serviceProvider != null) {
                         serviceProviderName = serviceProvider.getApplicationName();
                         serviceProviderUUID = serviceProvider.getApplicationResourceId();
@@ -189,16 +204,65 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                         log.debug("Error occurred while getting the Service Provider by Consumer key: "
                                 + oAuth2IntrospectionResponseDTO.getClientId(), e);
                     }
+                } catch (OrganizationManagementException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error occurred while checking the tenant domain: " +
+                                authorizedUserTenantDomain + " is an organization.", e);
+                    }
+                }
+
+                /*
+                 Set OAuthAppDO to the authentication context to be used when checking the user belongs to the
+                 requested tenant. This needs to be executed in the sub organization level.
+                */
+                OAuthAppDO oAuthAppDO = null;
+                try {
+                    if (StringUtils.isNotEmpty(authorizedUserTenantDomain) && OrganizationManagementUtil.
+                            isOrganization(authorizedUserTenantDomain)) {
+                        oAuthAppDO = OAuth2Util.getAppInformationByClientId(
+                                oAuth2IntrospectionResponseDTO.getClientId(), authorizedUserTenantDomain);
+                    }
+                } catch (IdentityOAuth2Exception | InvalidOAuthClientException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error occurred while getting the OAuth App by Consumer key: "
+                                + oAuth2IntrospectionResponseDTO.getClientId() + " and tenant domain: " +
+                                authorizedUserTenantDomain, e);
+                    }
+                } catch (OrganizationManagementException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error occurred while checking the tenant domain: " +
+                                authorizedUserTenantDomain + " is an organization.", e);
+                    }
+                }
+                if (oAuthAppDO != null) {
+                    authenticationContext.addParameter(Constants.AUTH_CONTEXT_OAUTH_APP_PROPERTY, oAuthAppDO);
                 }
 
                 String serviceProviderTenantDomain = null;
                 try {
-                    serviceProviderTenantDomain =
-                            OAuth2Util.getTenantDomainOfOauthApp(oAuth2IntrospectionResponseDTO.getClientId());
+                    /*
+                     Tokens which are issued for the applications which are registered in sub organization,
+                     contains the tenant domain for the authorized user as the sub organization. Based on that
+                     we can get the application tenant domain detail by using both the client id and the tenant domain.
+                    */
+                    if (StringUtils.isNotEmpty(authorizedUserTenantDomain) && OrganizationManagementUtil.
+                            isOrganization(authorizedUserTenantDomain)) {
+                        serviceProviderTenantDomain =
+                                OAuth2Util.getTenantDomainOfOauthApp(oAuth2IntrospectionResponseDTO.getClientId(),
+                                        authorizedUserTenantDomain);
+                    } else {
+                        serviceProviderTenantDomain =
+                                OAuth2Util.getTenantDomainOfOauthApp(oAuth2IntrospectionResponseDTO.getClientId());
+                    }
                 } catch (InvalidOAuthClientException | IdentityOAuth2Exception e) {
                     if (log.isDebugEnabled()) {
                         log.debug("Error occurred while getting the OAuth App tenantDomain by Consumer key: "
                                 + oAuth2IntrospectionResponseDTO.getClientId(), e);
+                    }
+                } catch (OrganizationManagementException e) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Error occurred while checking the tenant domain: " +
+                                authorizedUserTenantDomain + " is an organization.", e);
                     }
                 }
 

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
@@ -94,7 +94,14 @@ public class Utils {
         // Check request with organization qualified URL is allowed to access.
         String organizationID = getOrganizationIdFromURLMapping(request);
         if (user != null) {
-            return StringUtils.equals(organizationID, ((AuthenticatedUser) user).getAccessingOrganization());
+            if (StringUtils.equals(organizationID, ((AuthenticatedUser) user).getAccessingOrganization())) {
+                return true;
+            } else {
+                OAuthAppDO oAuthAppDO = (OAuthAppDO) authenticationContext.getParameter(
+                        Constants.AUTH_CONTEXT_OAUTH_APP_PROPERTY);
+                tenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
+                return StringUtils.equals(((AuthenticatedUser) user).getAccessingOrganization(), tenantDomain);
+            }
         }
         return false;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
         <identity.framework.version>7.3.13</identity.framework.version>
         <carbon.identity.package.import.version.range>[5.17.8, 8.0.0)</carbon.identity.package.import.version.range>
 
-        <org.wso2.carbon.identity.oauth.version>7.0.65</org.wso2.carbon.identity.oauth.version>
+        <org.wso2.carbon.identity.oauth.version>7.0.213</org.wso2.carbon.identity.oauth.version>
         <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 8.0.0)
         </org.wso2.carbon.identity.oauth.import.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject
- Allowing the sub organization application to use token endpoint with `/t/{tenant-domain}/o/{org-id}/` path to issue tokens.
- Part of the fix for : https://github.com/wso2/product-is/issues/21208