### PR TITLE
Update GitHub actions cache version for V4

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:


### PR DESCRIPTION
### Proposed changes in this pull request

- $subject since V2 is now deprecated and the PR builders are failing due to this[1][2].

[1] https://github.com/wso2-extensions/identity-carbon-auth-rest/actions/runs/13690613558/job/38283072563?pr=306
[2] https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down