### PR TITLE
Add allowed during impersonation config

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -52,6 +52,7 @@ import org.wso2.carbon.identity.core.handler.InitConfig;
 import org.wso2.carbon.identity.core.util.IdentityConfigParser;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.OAuth2Constants;
@@ -152,16 +153,20 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
                     return authenticationResult;
                 }
 
-                /* If the token is impersonated access token issued for MY_ACCOUNT, block all the actions excepts
-                for discoverable actions. */
-                boolean isValidOperation = validateAllowedDuringImpersonation(authenticationContext.getResourceConfig(),
-                        oAuth2IntrospectionResponseDTO.getScope(),
-                        oAuth2IntrospectionResponseDTO.getClientId());
-                if (!isValidOperation) {
-                    if (log.isDebugEnabled()) {
-                        log.debug("Not an allowed operation during impersonation.");
+                boolean isUserSessionImpersonationEnabled = OAuthServerConfiguration.getInstance()
+                        .isUserSessionImpersonationEnabled();
+                if (isUserSessionImpersonationEnabled) {
+                    /* If the token is impersonated access token issued for MY_ACCOUNT, block all the actions excepts
+                    for discoverable actions. */
+                    boolean isValidOperation = validateAllowedDuringImpersonation(authenticationContext.getResourceConfig(),
+                            oAuth2IntrospectionResponseDTO.getScope(),
+                            oAuth2IntrospectionResponseDTO.getClientId());
+                    if (!isValidOperation) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Not an allowed operation during impersonation.");
+                        }
+                        return authenticationResult;
                     }
-                    return authenticationResult;
                 }
 
                 // If the request is coming to me endpoint, store the token id to the thread local.

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/OAuth2AccessTokenHandler.java
@@ -332,7 +332,7 @@ public class OAuth2AccessTokenHandler extends AuthenticationHandler {
      * @param resourceConfig Resource Config.
      * @param allowedScopes  Allowed scopes in the token.
      * @param clientId       Client id.
-     * @return Whether operation or not.
+     * @return Whether the operation is allowed or not.
      */
     private boolean validateAllowedDuringImpersonation(ResourceConfig resourceConfig, String allowedScopes,
                                                        String clientId) {

--- a/pom.xml
+++ b/pom.xml
@@ -438,10 +438,10 @@
         <org.wso2.carbon.identity.cors.valve.version>${project.version}</org.wso2.carbon.identity.cors.valve.version>
 
         <!--Carbon identity version-->
-        <identity.framework.version>7.7.138</identity.framework.version>
+        <identity.framework.version>7.8.123</identity.framework.version>
         <carbon.identity.package.import.version.range>[5.17.8, 8.0.0)</carbon.identity.package.import.version.range>
 
-        <org.wso2.carbon.identity.oauth.version>7.0.213</org.wso2.carbon.identity.oauth.version>
+        <org.wso2.carbon.identity.oauth.version>7.0.288</org.wso2.carbon.identity.oauth.version>
         <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 8.0.0)
         </org.wso2.carbon.identity.oauth.import.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
> Introduce `allowed-during-impersonation` config to mark an API as allowed during impersonation. This is specific to MY ACCOUNT app as of now. 

Sample
`<Resource context="(.*)/o/api/server/v1/branding-preference(.*)" allowed-during-impersonation="true" secured="false" http-method="GET" />`

### Related Issues:
- https://github.com/wso2/product-is/issues/23462