### PR TITLE
Update tenant resolver valve to process non oAuth requests

### DIFF
--- a/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/OAuthAppTenantResolverValve.java
+++ b/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/OAuthAppTenantResolverValve.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.exception.InvalidOAuthClientException;
@@ -97,7 +98,7 @@ public class OAuthAppTenantResolverValve extends ValveBase {
                 PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
                 carbonContext.setTenantDomain(appTenant);
                 carbonContext.setTenantId(IdentityTenantUtil.getTenantId(appTenant));
-                startTenantFlow(appTenant);
+                FrameworkUtils.startTenantFlow(appTenant);
             }
 
             getNext().invoke(request, response);
@@ -105,22 +106,6 @@ public class OAuthAppTenantResolverValve extends ValveBase {
             // Clear thread local tenant name.
             unsetThreadLocalContextTenantName();
         }
-    }
-
-    /**
-     * Starts a tenant flow after resolving the current tenant domain when tenant qualified URLs are disabled.
-     *
-     * @param tenantDomain Tenant Domain.
-     */
-    private void startTenantFlow(String tenantDomain) {
-
-        String userId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
-        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-
-        PrivilegedCarbonContext.startTenantFlow();
-        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain);
-        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(tenantId);
-        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserId(userId);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.auth.valve/src/test/java/org/wso2/carbon/identity/auth/valve/OAuthAppTenantResolverValveTest.java
+++ b/components/org.wso2.carbon.identity.auth.valve/src/test/java/org/wso2/carbon/identity/auth/valve/OAuthAppTenantResolverValveTest.java
@@ -30,8 +30,11 @@ import org.powermock.reflect.Whitebox;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.context.internal.CarbonContextDataHolder;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
@@ -56,7 +59,7 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OAuth20Params
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.TENANT_NAME_FROM_CONTEXT;
 
 @PrepareForTest({OAuthAppTenantResolverValve.class, OAuth2Util.class, LoggerUtils.class,
-        OAuthServerConfiguration.class, IdentityUtil.class})
+        OAuthServerConfiguration.class, IdentityUtil.class, PrivilegedCarbonContext.class, IdentityTenantUtil.class})
 public class OAuthAppTenantResolverValveTest extends PowerMockTestCase {
 
     private static final String DUMMY_RESOURCE_OAUTH_2 = "https://localhost:9443/oauth2/test/resource";
@@ -91,6 +94,12 @@ public class OAuthAppTenantResolverValveTest extends PowerMockTestCase {
         user.setUserName("user1");
         oAuthAppDO = new OAuthAppDO();
         oAuthAppDO.setAppOwner(user);
+
+        mockStatic(PrivilegedCarbonContext.class);
+        when(PrivilegedCarbonContext.getThreadLocalCarbonContext()).thenReturn(mock(PrivilegedCarbonContext.class));
+
+        mockStatic(IdentityTenantUtil.class);
+        when(IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(1);
 
         OAuthServerConfiguration oAuthServerConfigurationMock = mock(OAuthServerConfiguration.class);
         mockStatic(OAuthServerConfiguration.class);

--- a/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
+++ b/components/org.wso2.carbon.identity.authz.valve/src/main/java/org/wso2/carbon/identity/authz/valve/util/Utils.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.auth.service.util.Constants;
 import org.wso2.carbon.identity.authz.service.AuthorizationContext;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.dao.OAuthAppDO;
 import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
@@ -90,6 +91,14 @@ public class Utils {
                     Constants.AUTH_CONTEXT_OAUTH_APP_PROPERTY);
             tenantDomain = OAuth2Util.getTenantDomainOfOauthApp(oAuthAppDO);
         }
+
+        // If tenant qualified URls are disabled get the requested tenant domain from carbon context
+        if (!IdentityTenantUtil.isTenantQualifiedUrlsEnabled()) {
+            String tenantDomainFromCarbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .getTenantDomain();
+            return tenantDomainFromCarbonContext.equals(tenantDomain);
+        }
+
         if (tenantDomainFromURLMapping.equals(tenantDomain)) {
             return true;
         }

--- a/pom.xml
+++ b/pom.xml
@@ -441,7 +441,7 @@
         <identity.framework.version>7.8.123</identity.framework.version>
         <carbon.identity.package.import.version.range>[5.17.8, 8.0.0)</carbon.identity.package.import.version.range>
 
-        <org.wso2.carbon.identity.oauth.version>7.0.288</org.wso2.carbon.identity.oauth.version>
+        <org.wso2.carbon.identity.oauth.version>7.0.296</org.wso2.carbon.identity.oauth.version>
         <org.wso2.carbon.identity.oauth.import.version.range>[6.2.18, 8.0.0)
         </org.wso2.carbon.identity.oauth.import.version.range>
 


### PR DESCRIPTION
### Purpose
This PR updates the tenant resolver valve to handle non-OAuth requests. The valve utilizes the authorization header value to retrieve the tenant.

### Related PRs (Merge first)
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2793

Note the build is failing due to above dependency. 

### Related Issue
- https://github.com/wso2/product-is/issues/23710