### PR TITLE
Add thumbprint user & system user mapping support 

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientCertificateBasedAuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/impl/ClientCertificateBasedAuthenticationHandler.java
@@ -1,28 +1,28 @@
 /*
+ * Copyright (c) 2016-2025, WSO2 LLC. (https://www.wso2.com).
  *
- *  Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
- *  Version 2.0 (the "License"); you may not use this file except
- *   in compliance with the License.
- *   you may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
- *   Unless required by applicable law or agreed to in writing,
- *   software distributed under the License is distributed on an
- *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *   KIND, either express or implied.  See the License for the
- *   specific language governing permissions and limitations
- *   under the License.
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.auth.service.handler.impl;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.auth.service.AuthenticationContext;
 import org.wso2.carbon.identity.auth.service.AuthenticationResult;
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.auth.service.exception.AuthServerException;
 import org.wso2.carbon.identity.auth.service.exception.AuthenticationFailException;
 import org.wso2.carbon.identity.auth.service.handler.AuthenticationHandler;
 import org.wso2.carbon.identity.auth.service.util.AuthConfigurationUtil;
+import org.wso2.carbon.identity.auth.service.util.Constants;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.context.IdentityContext;
 import org.wso2.carbon.identity.core.context.model.ApplicationActor;
@@ -41,7 +42,12 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import org.wso2.carbon.utils.multitenancy.MultitenantUtils;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Optional;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
@@ -76,12 +82,21 @@ public class ClientCertificateBasedAuthenticationHandler extends AuthenticationH
 
     @Override
     public boolean canHandle(MessageContext messageContext) {
+
         if (messageContext instanceof AuthenticationContext) {
             AuthenticationContext authenticationContext = (AuthenticationContext) messageContext;
             if (authenticationContext.getAuthenticationRequest() != null &&
                     authenticationContext.getAuthenticationRequest().
                             getAttribute(CLIENT_CERTIFICATE_ATTRIBUTE_NAME) != null) {
-                return true;
+                if (requireIntermediateCertValidation(authenticationContext)) {
+                    log.debug("Intermediate certificate validation is enabled.");
+                    return true;
+                }
+                if (AuthConfigurationUtil.getInstance().IsClientCertBasedAuthnEnabled()) {
+                    log.debug("Client certificate based authentication is enabled.");
+                    return true;
+                }
+                return false;
             }
         }
         return false;
@@ -101,18 +116,18 @@ public class ClientCertificateBasedAuthenticationHandler extends AuthenticationH
                     ) {
 
                 String username = authenticationContext.getAuthenticationRequest().getHeader(USER_HEADER_NAME);
+                Object object = authenticationContext.getAuthenticationRequest()
+                        .getAttribute(CLIENT_CERTIFICATE_ATTRIBUTE_NAME);
+                if (!(object instanceof X509Certificate[])) {
+                    throw new AuthenticationFailException("Exception while casting the X509Certificate.");
+                }
+                X509Certificate[] certificates = (X509Certificate[]) object;
+                if (certificates.length == 0) {
+                    throw new AuthenticationFailException("X509Certificate object is null.");
+                }
+                X509Certificate cert = certificates[0];
 
                 if (requireIntermediateCertValidation(authenticationContext)) {
-                    Object object = authenticationContext.getAuthenticationRequest()
-                            .getAttribute(CLIENT_CERTIFICATE_ATTRIBUTE_NAME);
-                    if (!(object instanceof X509Certificate[])) {
-                        throw new AuthenticationFailException("Exception while casting the X509Certificate.");
-                    }
-                    X509Certificate[] certificates = (X509Certificate[]) object;
-                    if (certificates.length == 0) {
-                        throw new AuthenticationFailException("X509Certificate object is null.");
-                    }
-                    X509Certificate cert = certificates[0];
                     try {
                         username = getCN(cert.getSubjectDN().getName());
                     } catch (InvalidNameException e) {
@@ -134,7 +149,142 @@ public class ClientCertificateBasedAuthenticationHandler extends AuthenticationH
                                 " called by user: "+ username + ".");
                         return authenticationResult;
                     }
+                } else {
+                    final String certIssuer;
+                    final String thumbprint;
+                    try {
+                        certIssuer = cert.getIssuerDN().getName();
+                        if (StringUtils.isEmpty(certIssuer)) {
+                            log.debug("Authentication failed. Issuer of the certificate is empty.");
+                            return authenticationResult;
+                        }
+                        thumbprint = getSha256Fingerprint(cert);
+                    } catch (CertificateEncodingException | NoSuchAlgorithmException e) {
+                        throw new AuthenticationFailException("Error occurred while retrieving certificate " +
+                                "thumbprint.", e);
+                    }
+
+                    if (AuthConfigurationUtil.getInstance().IsLogEnabled()) {
+                        log.info("mTLS Certificate Thumbprint : " + thumbprint + ", Issuer : " + certIssuer +
+                                " for the request made by user: " + username);
+                    }
+                    if (StringUtils.isNotEmpty(username)) {
+                        //  USER-BASED AUTH
+                        List<AuthConfigurationUtil.CertUserMapping> certUserMapping =
+                                AuthConfigurationUtil.getInstance().getCertUserMappings();
+
+                        if (CollectionUtils.isEmpty(certUserMapping)) {
+                            // At least one mapping with trusted issuer should exist.
+                            log.debug("User based authentication failed. User and cert mapping is not configured.");
+                            return authenticationResult;
+                        }
+
+                        if (!doesIssuerExistsInAllowedListForUserBasedAuthn(certUserMapping, certIssuer)) {
+                            log.debug("User based authentication failed. Issuer of the certificate " +
+                                    "does not exist in the trusted issuer list.");
+                            return authenticationResult;
+                        }
+
+                        // 1) Exact mapping for this thumbprint → pick the FIRST
+                        Optional<AuthConfigurationUtil.CertUserMapping> exactMatch =
+                                certUserMapping.stream()
+                                        .filter(m -> isDNEqual(certIssuer, m.getAllowedIssuer()) &&
+                                                thumbprint.equals(m.getAllowedThumbprint()))
+                                        .findFirst();
+
+                        if (exactMatch.isPresent()) {
+                            List<String> allowedUsers = exactMatch.get().getAllowedUsernames();
+                            if (allowedUsers.contains(Constants.WILDCARD)) {
+                                log.debug("Wildcard user found. Allowing the user to proceed with " +
+                                        "User based authentication.");
+                            } else if (!checkUserExistenceInAllowedList(allowedUsers, username)) {
+                                log.debug("Authentication failed. Username from the header is not in the " +
+                                        "allowed user list.");
+                                return authenticationResult;
+                            }
+                        } else {
+
+                            //  No exact thumbprint mapping, trying wildcard mapping ("*")
+                            Optional<AuthConfigurationUtil.CertUserMapping> wildcardMap =
+                                    certUserMapping.stream()
+                                            .filter(m -> isDNEqual(certIssuer, m.getAllowedIssuer())
+                                                    && Constants.WILDCARD.equals(m.getAllowedThumbprint()))
+                                            .findFirst();
+
+                            if (wildcardMap.isPresent()) {
+                                List<String> allowedUsers = wildcardMap.get().getAllowedUsernames();
+                                if (allowedUsers.contains(Constants.WILDCARD)) {
+                                    log.debug("Wildcard user found. Allowing the user to proceed with " +
+                                            "User based authentication.");
+                                } else if (!checkUserExistenceInAllowedList(allowedUsers, username)) {
+                                    log.debug("Authentication failed. Username from the header is not in the " +
+                                            "allowed user list.");
+                                    return authenticationResult;
+                                }
+                            } else {
+                                log.debug("Authentication failed. No thumbprint mapping found for the issuer.");
+                                return authenticationResult;
+                            }
+                        }
+                    } else {
+                        //  M2M / SYSTEM AUTH
+                        List<AuthConfigurationUtil.SystemThumbprintMapping> systemUserThumbprintMappings =
+                                AuthConfigurationUtil.getInstance().getSystemUserThumbprintMappings();
+
+                        if (CollectionUtils.isEmpty(systemUserThumbprintMappings)) {
+                            // At least one mapping with trusted issuer should exists
+                            log.debug("Authentication failed. System user and thumbprint mapping is not " +
+                                    "configured.");
+                            return authenticationResult;
+                        }
+
+                        if (!doesIssuerExistsInAllowedList(systemUserThumbprintMappings, certIssuer)) {
+                            log.debug("Authentication failed. Issuer of the certificate does not exist" +
+                                    " in the trusted issuer list.");
+                            return authenticationResult;
+                        }
+
+                        // 1) Exact mapping for this thumbprint → pick the FIRST
+                        Optional<AuthConfigurationUtil.SystemThumbprintMapping> exactMatch =
+                                systemUserThumbprintMappings.stream()
+                                        .filter(m ->
+                                                isDNEqual(certIssuer, m.getAllowedIssuer())
+                                                        && thumbprint.equalsIgnoreCase(m.getAllowedThumbprint()))
+                                        .findFirst();
+
+                        if (exactMatch.isPresent()) {
+                            String allowedUser = exactMatch.get().getAllowedSystemUser();
+                            if (Constants.WILDCARD.equals(allowedUser)) {
+                                // When the wildcard is set as the system user, we do not set any user in the context.
+                                authenticationResult.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
+                                return authenticationResult;
+                            }
+                            username = allowedUser;
+                        } else {
+                            // No exact system thumbprint mapping. Trying wildcard thumbprint mapping ("*")
+                            Optional<AuthConfigurationUtil.SystemThumbprintMapping> wildcardMap =
+                                    systemUserThumbprintMappings.stream()
+                                            .filter(m ->
+                                                    isDNEqual(certIssuer, m.getAllowedIssuer())
+                                                            && Constants.WILDCARD.equals(m.getAllowedThumbprint()))
+                                            .findFirst();
+
+                            if (wildcardMap.isPresent()) {
+                                String allowedUser = wildcardMap.get().getAllowedSystemUser();
+                                if (Constants.WILDCARD.equals(allowedUser)) {
+                                    // To preserver the backward compatible behaviour.
+                                    authenticationResult.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
+                                    return authenticationResult;
+                                }
+                                username = allowedUser;
+                            } else {
+                                log.debug("Authentication failed. No thumbprint mapping found for the issuer.");
+                                return authenticationResult;
+                            }
+                        }
+                    }
                 }
+
                 if (StringUtils.isNotEmpty(username)) {
                     String tenantDomain = MultitenantUtils.getTenantDomain(username);
 
@@ -150,7 +300,7 @@ public class ClientCertificateBasedAuthenticationHandler extends AuthenticationH
                     String userStoreDomain = UserCoreUtil.extractDomainFromName(username);
                     username = UserCoreUtil.removeDomainFromName(username);
 
-                    User user = new User();
+                    AuthenticatedUser user = new AuthenticatedUser();
                     user.setUserName(MultitenantUtils.getTenantAwareUsername(username));
                     user.setTenantDomain(tenantDomain);
                     user.setUserStoreDomain(userStoreDomain);
@@ -168,11 +318,33 @@ public class ClientCertificateBasedAuthenticationHandler extends AuthenticationH
                     //Server to server authentication. No user involves
                     authenticationResult.setAuthenticationStatus(AuthenticationStatus.SUCCESS);
                 }
-
             }
         }
 
         return authenticationResult;
+    }
+
+    private boolean doesIssuerExistsInAllowedList(
+            List<AuthConfigurationUtil.SystemThumbprintMapping> systemUserThumbprintMappings, String certIssuer) {
+
+        Optional<AuthConfigurationUtil.SystemThumbprintMapping> issuerExists =
+                systemUserThumbprintMappings.stream()
+                        .filter(m -> isDNEqual(certIssuer, m.getAllowedIssuer()))
+                        .findFirst();
+
+        return issuerExists.isPresent();
+    }
+
+    private boolean doesIssuerExistsInAllowedListForUserBasedAuthn(
+            List<AuthConfigurationUtil.CertUserMapping> certUserMapping, String certIssuer) {
+
+
+        Optional<AuthConfigurationUtil.CertUserMapping> issuerExists =
+                certUserMapping.stream()
+                        .filter(m -> isDNEqual(certIssuer,m.getAllowedIssuer()))
+                        .findFirst();
+
+        return issuerExists.isPresent();
     }
 
     /**
@@ -193,6 +365,17 @@ public class ClientCertificateBasedAuthenticationHandler extends AuthenticationH
         }
         return true;
     }
+
+    // Check whether the user exists in the allowed user list.
+    private boolean checkUserExistenceInAllowedList(List<String> values, String probe) {
+
+        if (values == null || StringUtils.isEmpty(probe)) return false;
+        for (String v : values) {
+            if (StringUtils.equalsIgnoreCase(v, probe)) return true;
+        }
+        return false;
+    }
+
 
     /**
      * Retrieve the common name from the subject DN.
@@ -218,5 +401,108 @@ public class ClientCertificateBasedAuthenticationHandler extends AuthenticationH
                 .username(user.getUserName())
                 .build();
         IdentityContext.getThreadLocalIdentityContext().setActor(userActor);
+    }
+
+    // Generate SHA-256 fingerprint of the certificate.
+    private String getSha256Fingerprint(X509Certificate cert)
+            throws CertificateEncodingException, NoSuchAlgorithmException {
+
+        byte[] encoded = cert.getEncoded();
+        MessageDigest md = MessageDigest.getInstance("SHA-256");
+        byte[] digest = md.digest(encoded);
+
+        StringBuilder fingerprint = new StringBuilder();
+        for (byte b : digest) {
+            fingerprint.append(String.format("%02X:", b));
+        }
+
+        // Remove trailing colon
+        if (fingerprint.length() > 0) {
+            fingerprint.setLength(fingerprint.length() - 1);
+        }
+
+        return fingerprint.toString();
+    }
+
+    // Check if the two DNs are equal after normalizing them.
+    private boolean isDNEqual(String certDN, String trustedDN) {
+
+        if (StringUtils.isEmpty(trustedDN) || StringUtils.isEmpty(certDN)) {
+            return false;
+        }
+        if (StringUtils.isEmpty(trustedDN) && StringUtils.isEmpty(certDN)) {
+            return false;
+        }
+
+        if (certDN.equals(trustedDN)) {
+            return true;
+        }
+
+        // Normalize and compare DN components.
+        String normalizedDN1 = normalizeDN(certDN);
+        String normalizedDN2 = normalizeDN(trustedDN);
+
+        return normalizedDN1.equals(normalizedDN2);
+    }
+
+    /**
+     * Helper method to normalize a Distinguished Name by sorting its components.
+     * This ensures that DNs with the same components in different orders are normalized to the same string.
+     *
+     * @param dn Distinguished Name to normalize
+     * @return Normalized DN string with components sorted alphabetically
+     */
+    private static String normalizeDN(String dn) {
+
+        if (dn == null || dn.trim().isEmpty()) {
+            return dn;
+        }
+
+        try {
+            // Split DN into components and normalize each.
+            String[] components = dn.split(",");
+            String[] normalizedComponents = new String[components.length];
+
+            for (int i = 0; i < components.length; i++) {
+                String component = components[i].trim();
+                // Normalize whitespace around the equals sign.
+                if (component.contains("=")) {
+                    String[] parts = component.split("=", 2);
+                    if (parts.length == 2) {
+                        normalizedComponents[i] = parts[0].trim().toUpperCase() + "=" + parts[1].trim();
+                    } else {
+                        normalizedComponents[i] = component;
+                    }
+                } else {
+                    normalizedComponents[i] = component;
+                }
+            }
+
+            // Sort components to ensure consistent ordering.
+            java.util.Arrays.sort(normalizedComponents);
+
+            StringBuilder normalized = new StringBuilder();
+            for (int i = 0; i < normalizedComponents.length; i++) {
+                if (i > 0) {
+                    normalized.append(", ");
+                }
+                normalized.append(normalizedComponents[i]);
+            }
+
+            String result = normalized.toString();
+
+            if (log.isDebugEnabled()) {
+                if (!dn.equals(result)) {
+                    log.debug("Normalized DN from '" + dn + "' to '" + result + "'");
+                }
+            }
+
+            return result;
+        } catch (Exception e) {
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to normalize DN: " + dn + ". Using original DN. Error: " + e.getMessage());
+            }
+            return dn; // Return original DN if normalization fails.
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/internal/AuthenticationServiceComponent.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/internal/AuthenticationServiceComponent.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2025, WSO2 LLC. (https://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.wso2.carbon.identity.auth.service.internal;
 
 import org.apache.commons.logging.Log;
@@ -69,6 +70,7 @@ public class AuthenticationServiceComponent {
             AuthConfigurationUtil.getInstance().buildSkipAuthorizationAllowedEndpointsData();
             AuthConfigurationUtil.getInstance().buildClientAuthenticationHandlerControlData();
             AuthConfigurationUtil.getInstance().buildIntermediateCertValidationConfigData();
+            AuthConfigurationUtil.getInstance().buildClientCertBasedAuthnEnabled();
             if (log.isDebugEnabled())
                 log.debug("AuthenticatorService is activated");
             if (clientAuthenticationHandler.hasDefaultCredentialsUsed()) {

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/AuthConfigurationUtil.java
@@ -54,6 +54,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -77,9 +78,13 @@ public class AuthConfigurationUtil {
     private Map<ResourceConfigKey, ResourceConfig> resourceConfigMap = new LinkedHashMap<>();
     private Map<String, String> applicationConfigMap = new HashMap<>();
     private List<String> intermediateCertCNList = new ArrayList<>();
+    private List<CertUserMapping> userThumbPrintMappings = new ArrayList<>();
+    private List<SystemThumbprintMapping> systemThumbprintMappings = new ArrayList<>();
     private List<String> exemptedContextList = new ArrayList<>();
     private Map<String, String[]> skipAuthorizationAllowedEndpoints = new HashMap<>();
     private boolean isIntermediateCertValidationEnabled = false;
+    private boolean clientCertBasedAuthnLogEnabled = false;
+    private boolean isClientCertBasedAuthnEnabled = false;
     private static final String SECRET_ALIAS = "secretAlias";
     private static final String SECRET_ALIAS_NAMESPACE_URI = "http://org.wso2.securevault/configuration";
     private static final String SECRET_ALIAS_PREFIX = "svns";
@@ -89,6 +94,58 @@ public class AuthConfigurationUtil {
     private boolean isScopeValidationEnabled = true;
 
     private static final Log log = LogFactory.getLog(AuthConfigurationUtil.class);
+
+    public static class CertUserMapping {
+
+        private final String certifiedIssuer;
+        private final String certThumbprint;
+        private final ArrayList<String> allowedUsernames;
+
+        public CertUserMapping(String certifiedIssuer, String certFingerPrint,
+                               ArrayList<String> allowedUsernames) {
+            this.certifiedIssuer = certifiedIssuer;
+            this.certThumbprint = certFingerPrint;
+            this.allowedUsernames = allowedUsernames;
+        }
+
+        public String getAllowedThumbprint() {
+            return certThumbprint;
+        }
+
+        public ArrayList<String> getAllowedUsernames() {
+            return allowedUsernames;
+        }
+
+        public String getAllowedIssuer() {
+            return certifiedIssuer;
+        }
+    }
+
+    public static class SystemThumbprintMapping {
+
+        private final String certThumbprint;
+        private final String allowedSystemUser;
+        private final String certifiedIssuer;
+
+        public SystemThumbprintMapping(String certifiedIssuer, String certThumbprint, String allowedSystemUser) {
+            this.certThumbprint = certThumbprint;
+            this.allowedSystemUser = allowedSystemUser;
+            this.certifiedIssuer = certifiedIssuer;
+        }
+
+        public String getAllowedThumbprint() {
+            return certThumbprint;
+        }
+
+        public String getAllowedSystemUser() {
+            return allowedSystemUser;
+        }
+
+        public String getAllowedIssuer() {
+            return certifiedIssuer;
+        }
+
+    }
 
     private AuthConfigurationUtil() {
     }
@@ -304,6 +361,110 @@ public class AuthConfigurationUtil {
     }
 
     /**
+     * Build cert based authentication enabled config.
+     */
+    public void buildClientCertBasedAuthnEnabled() {
+
+        OMElement root = IdentityConfigParser.getInstance()
+                .getConfigElement(Constants.CERT_BASED_AUTHENTICATION_ELE);
+
+        if (root != null) {
+            isClientCertBasedAuthnEnabled = Boolean.parseBoolean(
+                    root.getAttributeValue(new QName(Constants.CERT_AUTHENTICATION_ENABLE_ATTR)));
+        }
+        if (!isClientCertBasedAuthnEnabled) {
+            return;
+        }
+
+        OMElement logEnabledEle = root.getFirstChildWithName(
+                new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, Constants.LOG_CLIENT_CERT_INFO_ENABLED));
+        if (logEnabledEle == null) {
+            logEnabledEle = root.getFirstChildWithName(new QName(Constants.LOG_CLIENT_CERT_INFO_ENABLED));
+        }
+        clientCertBasedAuthnLogEnabled = logEnabledEle != null && Boolean.parseBoolean(logEnabledEle.getText());
+
+        OMElement userMappingsEle = root.getFirstChildWithName(
+                new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, Constants.USER_THUMBPRINT_MAPPINGS));
+        if (userMappingsEle != null) {
+            Iterator<OMElement> items = userMappingsEle.getChildrenWithName(
+                    new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, Constants.MAPPING));
+            while (items != null && items.hasNext()) {
+                OMElement m = items.next();
+
+                String trustedIssuer = getChildText(m, Constants.TRUSTED_ISSUER_ELE);
+                if (StringUtils.isEmpty(trustedIssuer)) {
+                    log.warn("Skipping user mapping: missing <TrustedIssuer>.");
+                    continue;
+                }
+
+                if (Constants.WILDCARD.equals(trustedIssuer)) {
+                    log.warn("Skipping user mapping: <TrustedIssuer> cannot be '*'.");
+                    continue;
+                }
+
+                String certThumbprint = getChildText(m, Constants.CERT_THUMBPRINT);
+                if (StringUtils.isEmpty(certThumbprint)) {
+                    certThumbprint = Constants.WILDCARD;
+                }
+
+                ArrayList<String> allowedUsers = new ArrayList<>(
+                        getChildrenTextList(m, Constants.ALLOWED_USERNAME, true)
+                );
+                if (allowedUsers.isEmpty()) {
+                    allowedUsers.add(Constants.WILDCARD);
+                }
+
+                userThumbPrintMappings.add(
+                        new CertUserMapping(
+                                trustedIssuer,
+                                certThumbprint,
+                                allowedUsers
+                        )
+                );
+            }
+        }
+
+        OMElement systemMappingsEle = root.getFirstChildWithName(
+                new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, Constants.SYSTEM_THUMBPRINT_MAPPINGS));
+        if (systemMappingsEle != null) {
+            Iterator<OMElement> items = systemMappingsEle.getChildrenWithName(
+                    new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, Constants.MAPPING));
+            while (items != null && items.hasNext()) {
+                OMElement m = items.next();
+
+                String trustedIssuer = getChildText(m, Constants.TRUSTED_ISSUER_ELE);
+                if (StringUtils.isEmpty(trustedIssuer)) {
+                    log.warn("Skipping system mapping: missing <TrustedIssuer>.");
+                    continue;
+                }
+
+                if (Constants.WILDCARD.equals(trustedIssuer)) {
+                    log.warn("Skipping sysem mapping: <TrustedIssuer> cannot be '*'.");
+                    continue;
+                }
+
+                String certThumbPrint = getChildText(m, Constants.CERT_THUMBPRINT);
+                if (StringUtils.isEmpty(certThumbPrint)) {
+                    certThumbPrint = Constants.WILDCARD;
+                }
+
+                String sysUser = getChildText(m, Constants.ALLOWED_SYSTEM_USER);
+                if (StringUtils.isEmpty(sysUser)) {
+                    sysUser = Constants.WILDCARD;
+                }
+
+                systemThumbprintMappings.add(
+                        new SystemThumbprintMapping(
+                                trustedIssuer,
+                                certThumbPrint,
+                                sysUser
+                        )
+                );
+            }
+        }
+    }
+
+    /**
      * Build intermediate cert validation config.
      */
     public void buildIntermediateCertValidationConfigData() {
@@ -376,6 +537,24 @@ public class AuthConfigurationUtil {
     public boolean isIntermediateCertValidationEnabled() {
 
         return isIntermediateCertValidationEnabled;
+    }
+
+    public boolean IsClientCertBasedAuthnEnabled() {
+
+        return isClientCertBasedAuthnEnabled;
+    }
+
+    public boolean IsLogEnabled() {
+
+        return clientCertBasedAuthnLogEnabled;
+    }
+
+    public List<CertUserMapping> getCertUserMappings() {
+        return userThumbPrintMappings;
+    }
+
+    public List<SystemThumbprintMapping> getSystemUserThumbprintMappings() {
+        return systemThumbprintMappings;
     }
 
     public List<String> getIntermediateCertCNList() {
@@ -515,5 +694,39 @@ public class AuthConfigurationUtil {
             }
         }
         return null;
+    }
+
+    private static QName qn(String local) {
+
+        return new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, local);
+    }
+
+    private static String getChildText(OMElement parent, String local) {
+
+        OMElement child = parent.getFirstChildWithName(qn(local));
+        return child != null ? StringUtils.trim(child.getText()) : null;
+    }
+
+    private static String safeText(OMElement ele) {
+
+        return ele == null ? null : StringUtils.trimToNull(ele.getText());
+    }
+
+    private static List<String> getChildrenTextList(OMElement parent, String childLocalName, boolean dedupe) {
+
+        ArrayList<String> out = new ArrayList<>();
+        if (parent == null) return out;
+        Iterator<OMElement> kids = parent.getChildrenWithName(
+                new QName(IdentityCoreConstants.IDENTITY_DEFAULT_NAMESPACE, childLocalName));
+        while (kids != null && kids.hasNext()) {
+            String v = safeText(kids.next());
+            if (StringUtils.isNotEmpty(v)) out.add(v);
+        }
+        if (dedupe && !out.isEmpty()) {
+            LinkedHashSet<String> set = new LinkedHashSet<>(out);
+            out.clear();
+            out.addAll(set);
+        }
+        return out;
     }
 }

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -1,5 +1,22 @@
-package org.wso2.carbon.identity.auth.service.util;
+/*
+ * Copyright (c) 2016-2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
+package org.wso2.carbon.identity.auth.service.util;
 
 public class Constants {
 
@@ -32,10 +49,19 @@ public class Constants {
 
     public static final String INTERMEDIATE_CERT_VALIDATION_ELE = "IntermediateCertValidation";
     public static final String INTERMEDIATE_CERTS_ELE = "IntermediateCerts";
+    public static final String TRUSTED_ISSUER_ELE = "TrustedIssuer";
     public static final String EXEMPT_CONTEXT_ELE = "ExemptContext";
     public static final String CERT_CN_ELE = "CertCN";
+    public static final String USER_THUMBPRINT_MAPPINGS = "UserThumbprintMappings";
+    public static final String LOG_CLIENT_CERT_INFO_ENABLED = "LogClientCertInfoEnabled";
+    public static final String CERT_THUMBPRINT = "CertThumbprint";
+    public static final String MAPPING = "Mapping";
+    public static final String SYSTEM_THUMBPRINT_MAPPINGS = "SystemThumbprintMappings";
+    public static final String ALLOWED_USERNAME = "AllowedUsername";
+    public static final String ALLOWED_SYSTEM_USER = "AllowedSystemUser";
     public final static String CONTEXT_ELE = "Context";
     public final static String CERT_AUTHENTICATION_ENABLE_ATTR = "enable";
+    public final static String CERT_BASED_AUTHENTICATION_ELE = "ClientCertBasedAuthentication";
     public final static String DENY_DEFAULT_ACCESS = "deny";
 
     public final static String COOKIE_BASED_TOKEN_BINDING = "cookie";
@@ -88,4 +114,5 @@ public class Constants {
     public static final String HTTP_METHOD = "httpMethod";
     public static final String CLIENT_ID = "clientId";
     public static final String SCOPE = "scope";
+    public static final String WILDCARD = "*";
 }


### PR DESCRIPTION
### Proposed changes in this pull request
With this PR, we are introducing support to restrict the access to the REST APIs through cert based client authentication. 

```
[client_certificate_based_authentication]
enable = true

[[client_certificate_based_authentication.user_thumbprint_mapping]]
trusted_issuer = "RootCA DN"
cert_thumbprint = "78:9B:25:49:5A:A6:DA:74:9C:F7:A8:90:CE:B9:21:EA:EC:C7:22:2A:B3:77:41:1B:6D:48:22:91:98:A9:FD:47" 
allowed_username = ["admin", "user@tenant.com"]

[[client_certificate_based_authentication.system_thumbprint_mapping]]
trusted_issuer = "RootCA DN"
cert_thumbprint = "78:9B:25:49:5A:A6:DA:74:9C:F7:A8:90:CE:B9:21:EA:EC:C7:22:2A:B3:77:41:1B:6D:48:22:91:98:A9:FD:47"
allowed_system_user = "admin"
```

By enabling this, this certificate based authentication handler will validate whenther the certificate in the request is from the same issuer added in the configurations and if the thumbprints matches and are used by configured users. 

the thumbprint should be obtained using SHA-256 algorithm.