### PR TITLE
Set authenticated user to thread local

### DIFF
--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/handler/AuthenticationHandler.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.auth.service.exception.AuthClientException;
 import org.wso2.carbon.identity.auth.service.exception.AuthServerException;
 import org.wso2.carbon.identity.auth.service.exception.AuthenticationFailException;
 import org.wso2.carbon.identity.auth.service.internal.AuthenticationServiceHolder;
+import org.wso2.carbon.identity.auth.service.util.Constants;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.AbstractIdentityMessageHandler;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -119,6 +120,7 @@ public abstract class AuthenticationHandler extends AbstractIdentityMessageHandl
                     if (user instanceof AuthenticatedUser) {
                         PrivilegedCarbonContext.getThreadLocalCarbonContext()
                                 .setUserId(((AuthenticatedUser) user).getUserId());
+                        IdentityUtil.threadLocalProperties.get().put(Constants.AUTHENTICATED_USER, user);
                     } else {
                         AuthenticatedUser authenticatedUser = new AuthenticatedUser(user);
                         PrivilegedCarbonContext.getThreadLocalCarbonContext()

--- a/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
+++ b/components/org.wso2.carbon.identity.auth.service/src/main/java/org/wso2/carbon/identity/auth/service/util/Constants.java
@@ -88,4 +88,5 @@ public class Constants {
     public static final String HTTP_METHOD = "httpMethod";
     public static final String CLIENT_ID = "clientId";
     public static final String SCOPE = "scope";
+    public static final String AUTHENTICATED_USER = "authenticatedUser";
 }

--- a/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java
+++ b/components/org.wso2.carbon.identity.auth.valve/src/main/java/org/wso2/carbon/identity/auth/valve/AuthenticationValve.java
@@ -194,6 +194,8 @@ public class AuthenticationValve extends ValveBase {
 
             // Clear thread local service provider info.
             unsetThreadLocalServiceProvider();
+            // Clear thread local authenticated user.
+            IdentityUtil.threadLocalProperties.get().remove(Constants.AUTHENTICATED_USER);
             // Clear thread local current session id.
             unsetCurrentSessionIdThreadLocal();
             // Clear thread local authenticated user tenant domain.


### PR DESCRIPTION
### Proposed changes in this pull request
This pull request introduces a mechanism for tracking the authenticated user in thread-local storage during the authentication process. The changes ensure that the authenticated user is set after successful authentication and properly cleared after the request is processed, improving context management and thread safety.

**Thread-local authenticated user management:**

* Added a new constant `AUTHENTICATED_USER` to the `Constants` class for consistent reference to the authenticated user key.
* After successful authentication in `AuthenticationHandler`, the authenticated user is stored in thread-local properties using the new constant.
* The authenticated user is explicitly removed from thread-local properties in `AuthenticationValve` after the request is handled, ensuring cleanup and preventing leakage between requests.

**Code maintenance:**

* Imported the new `Constants` class in `AuthenticationHandler` to support the added functionality.