### PR TITLE
[1.8.x] Upgrade axis2 and axiom versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -378,11 +378,11 @@
         <imp.pkg.version.javax.servlet>[2.6.0, 3.0.0)</imp.pkg.version.javax.servlet>
 
         <!-- Axis2 Version -->
-        <axis2.wso2.version>1.6.1-wso2v105</axis2.wso2.version>
-        <axis2.osgi.version.range>[1.6.1-wso2v105, 2.0.0)</axis2.osgi.version.range>
+        <axis2.wso2.version>1.6.1-wso2v108</axis2.wso2.version>
+        <axis2.osgi.version.range>[1.6.1, 2.0.0)</axis2.osgi.version.range>
 
         <!-- Axiom Version -->
-        <axiom.wso2.version>1.2.11-wso2v29</axiom.wso2.version>
+        <axiom.wso2.version>1.2.11-wso2v30</axiom.wso2.version>
         <axiom.osgi.version.range>[1.2.11, 2.0.0)</axiom.osgi.version.range>
 
         <!-- Commons Version -->


### PR DESCRIPTION
### Proposed changes in this pull request

This pull request updates dependency versions in the `pom.xml` file to keep the project up-to-date with the latest compatible releases.

Dependency version updates:

* Updated the `axis2.wso2.version` from `1.6.1-wso2v105` to `1.6.1-wso2v108` and broadened the `axis2.osgi.version.range` to `[1.6.1, 2.0.0)`, removing the WSO2-specific qualifier for better compatibility.
* Updated the `axiom.wso2.version` from `1.2.11-wso2v29` to `1.2.11-wso2v30` for improved stability and bug fixes.
